### PR TITLE
Sphinx 1.4.5

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,8 @@
+0.2.0
+=====
+
+* This is a Breaking change. The PHP Domain can now run under sphinx 1.4.5.
+
 0.1.4
 =====
 
@@ -13,7 +18,7 @@
 0.1.2
 =====
 
-* Made it possible to not require class properties to be nested under the 
+* Made it possible to not require class properties to be nested under the
   class definition.
 * Added ``.. php:staticmethod:`` to solve ambiguity in method naming.
 * Added prefixes for a number of things, and removed classname as a prefix for

--- a/setup.py
+++ b/setup.py
@@ -9,11 +9,11 @@ This extension provides a PHP domain for sphinx
 
 '''
 
-requires = ['Sphinx>=1.0']
+requires = ['Sphinx>=1.3']
 
 setup(
     name='sphinxcontrib-phpdomain',
-    version='0.1.4',
+    version='0.2.0',
     url='http://bitbucket.org/markstory/sphinx-contrib',
     download_url='http://pypi.python.org/pypi/sphinxcontrib-phpdomain',
     license='BSD',

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -130,7 +130,7 @@ class PhpObject(ObjectDescription):
             fullname = name
         else:
             add_module = True
-            # name_prefix and a non-static method, means the classname was 
+            # name_prefix and a non-static method, means the classname was
             # repeated. Trim off the <class>::
             if name_prefix and self.objtype != 'staticmethod':
                 if name_prefix.startswith(classname):
@@ -254,7 +254,7 @@ class PhpObject(ObjectDescription):
         indextext = self.get_index_text(modname, name_cls)
         if indextext:
             self.indexnode['entries'].append(('single', indextext,
-                                              fullname, fullname))
+                                              fullname, fullname, None))
 
 
 
@@ -412,7 +412,7 @@ class PhpNamespace(Directive):
         if not noindex:
             indextext = _('%s (namespace)') % modname
             inode = addnodes.index(entries=[('single', indextext,
-                                             'namespace-' + modname, modname)])
+                                             'namespace-' + modname, modname, None)])
             ret.append(inode)
         return ret
 


### PR DESCRIPTION
This PR allows us to run docs under sphinx 1.4.5. This is a BC for people using an old version of sphinx.

We probably need to add tags to avoid BC changes, I don't know how it works for sphinx packages.