### PR TITLE
Don't fatally error on function nodes that include classnames.

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -123,6 +123,9 @@ class PhpObject(ObjectDescription):
         classname = self.env.temp_data.get('php:class')
         separator = separators[self.objtype]
 
+        # Method declared as Class::methodName
+        if not classname and '::' in name_prefix:
+            classname = name_prefix.rstrip('::')
         if self.objtype == 'global' or self.objtype == 'function':
             add_module = False
             modname = None

--- a/test/index.rst
+++ b/test/index.rst
@@ -8,7 +8,8 @@ Contents:
 
    test_doc
    test_doc2
-   
+   test_nesting_regression
+
 Indices and tables
 ==================
 

--- a/test/test_nesting_regression.rst
+++ b/test/test_nesting_regression.rst
@@ -1,0 +1,19 @@
+Nested method Regression
+========================
+
+Test nested methods to ensure page generation doesn't hard fail.
+
+.. php:method:: Largo_Byline::populate_variables()
+
+      Set us up the vars
+
+          - 'post_id': an integer post ID
+          - 'exclude_date': boolean whether or not to include the date in the byline
+
+      :param array $args: Associative array containing following keys:
+
+   .. php:method:: Largo_Byline::generate_byline()
+
+      this creates the byline text and adds it to $this->output
+
+      :see: $output $reates this


### PR DESCRIPTION
When `php:function` is used to annotate methods the build should not fail. However it will generate incorrect output as function should be used for global functions and not methods.

Refs #2