### PR TITLE
Fix problem that [] and , in argument list are swapped

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -22,7 +22,7 @@ from sphinx.directives import ObjectDescription
 from sphinx.util.nodes import make_refnode
 from sphinx.util.compat import Directive
 from sphinx.util.docfields import Field, GroupedField, TypedField
-
+from sphinx.domains.python import _pseudo_parse_arglist
 
 
 php_sig_re = re.compile(
@@ -33,8 +33,6 @@ php_sig_re = re.compile(
           )? $                   # and nothing more
           ''', re.VERBOSE)
 
-
-php_paramlist_re = re.compile(r'([\[\],])')  # split at '[', ']' and ','
 
 NS = '\\'
 
@@ -189,26 +187,8 @@ class PhpObject(ObjectDescription):
                 signode += addnodes.desc_returns(retann, retann)
             return fullname, name_prefix
 
-        signode += addnodes.desc_parameterlist()
+        _pseudo_parse_arglist(signode, arglist)
 
-        stack = [signode[-1]]
-        for token in php_paramlist_re.split(arglist):
-            if token == '[':
-                opt = addnodes.desc_optional()
-                stack[-1] += opt
-                stack.append(opt)
-            elif token == ']':
-                try:
-                    stack.pop()
-                except IndexError:
-                    raise ValueError
-            elif not token or token == ',' or token.isspace():
-                pass
-            else:
-                token = token.strip()
-                stack[-1] += addnodes.desc_parameter(token, token)
-        if len(stack) != 1:
-            raise ValueError
         if retann:
             signode += addnodes.desc_returns(retann, retann)
         return fullname, name_prefix

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -24,6 +24,7 @@ from sphinx.util.compat import Directive
 from sphinx.util.docfields import Field, GroupedField, TypedField
 
 
+
 php_sig_re = re.compile(
     r'''^ ([\w.]*\:\:)?          # class name(s)
           (\$?\w+)  \s*          # thing name


### PR DESCRIPTION
Code is fixed with reference to python domain coding.
https://github.com/sphinx-doc/sphinx/blob/master/sphinx/domains/javascript.py#L84

Problem happen in case below:

```
.. php:method:: inputs(array $fields = [], $options = [])
```

In this case, result should be:

```
Cake\View\Helper\FormHelper::inputs(array $fields = [], $options = []])
```

But actually wrong:

```
Cake\View\Helper\FormHelper::inputs(array $fields = , []$options = []])
```

Above problem already fixed by this PR.

----

Unfortunately, this code still has another comma defect. The defect emerges when in case below:

```
.. php:method:: foo(string $var =",", string $buz = true)
```

In this case, separating with comma, arguments become 3 of 'string $var="', '"', 'string $buz = true'.

However, last defect is a problem of _pseudo_parse_arglist that should be fixed in python domain, but, I think, it is not a problem of phpdomain.

In addition, it doesn't happen in cake3 doc because of there are no signature with "," default parameter as long as I've checked.

Thank you for reading.