### PR TITLE
add contextual open around requirements.txt read in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,8 @@
 import os
 from setuptools import setup, find_packages
 
-with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), 'r') as f:
+with open(os.path.join(os.path.dirname(__file__),
+                       'requirements.txt'), 'r') as f:
     requirements = f.read()
 
 long_desc = '''

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
-
+import os
 from setuptools import setup, find_packages
 
-requirements = open('./requirements.txt', 'r')
+with open(os.path.join(os.path.dirname(__file__), 'requirements.txt'), 'r') as f:
+    requirements = f.read()
 
 long_desc = '''
 This package contains the phpdomain Sphinx extension.
@@ -34,6 +35,6 @@ setup(
     platforms='any',
     packages=find_packages(),
     include_package_data=True,
-    install_requires=requirements.readlines(),
+    install_requires=requirements,
     namespace_packages=['sphinxcontrib'],
 )


### PR DESCRIPTION
This approach has several benefits:

- closes the opened file explicitly
- doesn't use an OS-dependent file separator to find `requirements.txt`
- doesn't make assumptions about curdir during the installation process via pip (which worked as-is under a Py2 environment, but choked under a Py3 environment)
