### PR TITLE
add requirements.txt to MANIFEST

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 include README
 include LICENSE
 include CHANGES
+include requirements.txt


### PR DESCRIPTION
In order to include requirements.txt in the source distribution, and thus make it available to `setup.py` for pip installs, it appears you must have it listed in `MANIFEST.in`. This should (I hope) finish addressing issue #10.