### PR TITLE
Allow visibility modifiers

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -22,13 +22,14 @@ from sphinx.util.nodes import make_refnode
 from sphinx.util.compat import Directive
 from sphinx.util.docfields import Field, GroupedField, TypedField
 
-
 php_sig_re = re.compile(
-    r'''^ ([\w.]*\:\:)?          # class name(s)
-          (\$?\w+)  \s*          # thing name
-          (?: \((.*)\)           # optional: arguments
-          (?:\s* -> \s* (.*))?   # return annotation
-          )? $                   # and nothing more
+    r'''^ (public\ |protected\ |private\ )? # visibility
+          (final\ |abstract\ |static\ )?    # modifiers
+          ([\w.]*\:\:)?                     # class name(s)
+          (\$?\w+)  \s*                     # thing name
+          (?: \((.*)\)                      # optional: arguments
+          (?:\s* -> \s* (.*))?              # return annotation
+          )? $                              # and nothing more
           ''', re.VERBOSE)
 
 
@@ -156,7 +157,7 @@ class PhpObject(ObjectDescription):
         if m is None:
             raise ValueError
 
-        name_prefix, name, arglist, retann = m.groups()
+        visibility, modifiers, name_prefix, name, arglist, retann = m.groups()
 
         if not name_prefix:
             name_prefix = ""
@@ -203,7 +204,13 @@ class PhpObject(ObjectDescription):
         signode['class'] = self.class_name = classname
         signode['fullname'] = fullname
 
+        if visibility:
+            signode += addnodes.desc_annotation(visibility, visibility)
+
         sig_prefix = self.get_signature_prefix(sig)
+
+        if modifiers and not (sig_prefix and 'static' in sig_prefix):
+                signode += addnodes.desc_annotation(modifiers, modifiers)
 
         if sig_prefix:
             signode += addnodes.desc_annotation(sig_prefix, sig_prefix)

--- a/test/test_doc.rst
+++ b/test/test_doc.rst
@@ -48,6 +48,12 @@ Classes
         :param int $minute: The minute
         :param int $second: The second
 
+    .. php:method:: public static getLastErrors()
+
+        Returns the warnings and errors
+
+        :returns: array Returns array containing info about warnings and errors.
+
     .. php:const:: ATOM
 
         Y-m-d\TH:i:sP
@@ -158,6 +164,8 @@ Test Case - Global symbols with no namespaces
 
 :php:func:`DateTime::setTime()`
 
+:php:func:`DateTime::getLastErrors()`
+
 :php:func:`~DateTime::setDate()`
 
 :php:func:`DateTime::ATOM`
@@ -252,6 +260,33 @@ Namespaced elements
 
     A static method here.
 
+.. php:class:: final LibraryClassFinal
+
+    A final class
+
+.. php:method:: public firstMethod($one, $two)
+
+    A public instance method.
+
+.. php:method:: protected secondMethod($one, $two)
+
+    A protected instance method.
+
+.. php:method:: private thirdMethod($one, $two)
+
+    A private instance method.
+
+.. php:method:: static fourthMethod($one, $two)
+
+    A static method.
+
+.. php:method:: protected final fivthMethod($one, $two)
+
+    A protected final method.
+
+.. php:class:: abstract LibraryClassAbstract
+
+    An abstract class
 
 .. php:interface:: LibraryInterface
 
@@ -298,6 +333,18 @@ Test Case - not including namespace
 :php:attr:`NamespaceClass::$property`
 
 :php:const:`NamespaceClass::NAMESPACE_CONST`
+
+:php:class:`LibraryClassFinal`
+
+:php:meth:`LibraryClassFinal::firstMethod`
+
+:php:meth:`LibraryClassFinal::secondMethod`
+
+:php:meth:`LibraryClassFinal::thirdMethod`
+
+:php:meth:`LibraryClassFinal::fourthMethod`
+
+:php:meth:`LibraryClassFinal::fivthMethod`
 
 :php:interface:`LibraryInterface`
 


### PR DESCRIPTION
This PR adds support for visibility definitions and modifiers like static/final/abstract.
Those will be added as annotation to the rendering and must be omitted when referencing the class,method or property.