### PR TITLE
Prepare for parallel read safety

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -605,10 +605,10 @@ class PhpDomain(Domain):
     ]
 
     def clear_doc(self, docname):
-        for fullname, (fn, _) in list(self.data['objects'].items()):
+        for fullname, (fn, _l) in list(self.data['objects'].items()):
             if fn == docname:
                 del self.data['objects'][fullname]
-        for ns, (fn, _, _) in list(self.data['namespaces'].items()):
+        for ns, (fn, _x, _x) in list(self.data['namespaces'].items()):
             if fn == docname:
                 del self.data['namespaces'][ns]
 

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -614,7 +614,7 @@ class PhpDomain(Domain):
 
     def merge_domaindata(self, docnames, otherdata):
         for fullname, (fn, objtype) in otherdata['objects'].items():
-            if fn in docname:
+            if fn in docnames:
                 self.data['objects'][fullname] = (fn, objtype)
         for namespace, data in otherdata['namespaces'].items():
             if data[0] in docnames:


### PR DESCRIPTION
Use builtin python domain as pattern for parallel read safety:

- revise clear_doc() to be in line with python domain's clear_doc()
- add merge_domain() built in the same mode as python domain's merge_domain()