### PR TITLE
Update for Sphinx 2.0.1

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -285,7 +285,7 @@ class PhpObject(ObjectDescription):
                     'duplicate object description of %s, ' % fullname +
                     'other instance in ' +
                     self.env.doc2path(objects[fullname][0]),
-                    line = self.lineno)
+                    line=self.lineno)
             objects[fullname] = (self.env.docname, self.objtype)
 
         indextext = self.get_index_text(modname, name_cls)

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -281,12 +281,11 @@ class PhpObject(ObjectDescription):
             self.state.document.note_explicit_target(signode)
             objects = self.env.domaindata['php']['objects']
             if fullname in objects:
-                self.env.warnings.warn(
-                    self.env.docname,
+                self.state_machine.reporter.warning(
                     'duplicate object description of %s, ' % fullname +
                     'other instance in ' +
                     self.env.doc2path(objects[fullname][0]),
-                    self.lineno)
+                    line = self.lineno)
             objects[fullname] = (self.env.docname, self.objtype)
 
         indextext = self.get_index_text(modname, name_cls)

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -281,7 +281,7 @@ class PhpObject(ObjectDescription):
             self.state.document.note_explicit_target(signode)
             objects = self.env.domaindata['php']['objects']
             if fullname in objects:
-                self.env.warn(
+                self.env.warnings.warn(
                     self.env.docname,
                     'duplicate object description of %s, ' % fullname +
                     'other instance in ' +


### PR DESCRIPTION
To avoid this error:

```
  File "/usr/local/lib/python3.7/site-packages/sphinxcontrib/phpdomain.py", line 284, in add_target_and_index
    self.env.warn(
AttributeError: 'BuildEnvironment' object has no attribute 'warn'
```

Solution from javascript domain:
 https://github.com/sphinx-doc/sphinx/blob/master/sphinx/domains/javascript.py#L112