### PR TITLE
Stop testing with old python

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python: ['2.7', '3.5', '3.9']
+        python: ['3.7', '3.8', '3.9']
       fail-fast: false
 
     steps:


### PR DESCRIPTION
2.7 is end of life, and dropping python 2 can be part of the next release.