### PR TITLE
process_link regexp change

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -491,7 +491,7 @@ class PhpXRefRole(XRefRole):
             # if the first character is a tilde, don't display the module/class
             # parts of the contents
             if title[0:1] == '~':
-                m = re.search(r"(?:\\|[:]{2})(.*)\Z", title)
+                m = re.search(r"(?:.+[:]{2}|(?:.*?\\{2})+)?(.*)\Z", title)
                 if m:
                     title = m.group(1)
 


### PR DESCRIPTION
Change the process_link regexp to actually hide all the parts before class/method name. Please see unit tests carried out on regex101: https://regex101.com/r/eNUo8C/1