### PR TITLE
Support PHP enumerations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 dist/
 build/
+doc/_build
 test/_build
 *.pyc
 *.egg-info

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -50,6 +50,62 @@ Each directive populates the index, and or the namespace index.
    Describe a trait.  Methods beloning to the trait should follow or be nested
    inside this directive.
 
+.. rst:directive:: .. php:enum:: name [ : type ]
+
+   Describes an enum. Cases, methods, and constants belonging to the enum
+   should be inside this directive's body::
+
+        .. php:enum:: Suit
+
+            In playing cards, a suit is one of the categories into which the
+            cards of a deck are divided.
+
+            .. php:case:: Hearts
+
+                Hearts is one of the four suits in playing cards.
+
+            .. php:case:: Diamonds
+
+                Diamonds is one of the four suits in playing cards.
+
+            .. php:case:: Clubs
+
+                Clubs is one of the four suits in playing cards.
+
+            .. php:case:: Spades
+
+                Spades is one of the four suits in playing cards.
+
+            .. php:method:: color() -> string
+
+                Returns "Red" for hearts and diamonds and "black" for clubs
+                and spades.
+
+            .. php:const:: Roses : Hearts
+
+                An alias for :php:case:`Suit::Hearts`.
+
+   You may describe a backed enum by specifying the optional enum type and
+   case values::
+
+        .. php:enum:: Suit : string
+
+            In playing cards, a suit is one of the categories into which the
+            cards of a deck are divided.
+
+            .. php:case:: Hearts : 'H'
+
+            .. php:case:: Diamonds : 'D'
+
+            .. php:case:: Clubs : 'C'
+
+            .. php:case:: Spades : 'S'
+
+.. rst:directive:: .. php:case:: name [ : value ]
+
+   Describes an enum case. If describing a backed enum case, you may also
+   provide the case value. See :rst:dir:`php:enum` for examples.
+
 .. rst:directive:: .. php:class:: name
 
    Describes a class.  Methods, attributes, and constants belonging to the class
@@ -166,3 +222,14 @@ matching directive is found:
 
    Reference a trait. A namespaced name may be used.
 
+.. rst:role:: php:enum
+
+   Reference an enum. A namespaced name may be used::
+
+     :php:enum:`Example\\Suit`
+
+.. rst:role:: php:case
+
+   Reference an enum case. A namespace name may be used::
+
+     :php:case:`Example\\Suit::Hearts`

--- a/test/test_doc.rst
+++ b/test/test_doc.rst
@@ -472,3 +472,129 @@ Return Types
 .. php:class:: ReturnedClass
 
     A class to return.
+
+Enums
+=====
+
+Basic Enumerations
+------------------
+
+.. php:namespace:: Example\Basic
+
+.. php:enum:: Suit
+
+    In playing cards, a suit is one of the categories into which the cards of a
+    deck are divided.
+
+    .. php:case:: Hearts
+    .. php:case:: Diamonds
+    .. php:case:: Clubs
+    .. php:case:: Spades
+
+Backed Enumerations
+-------------------
+
+.. php:namespace:: Example\Backed
+
+.. php:enum:: Suit : string
+
+    In playing cards, a suit is one of the categories into which the cards of a
+    deck are divided.
+
+    .. php:case:: Hearts : 'H'
+    .. php:case:: Diamonds : 'D'
+    .. php:case:: Clubs : 'C'
+    .. php:case:: Spades : 'S'
+
+Advanced Enumerations
+---------------------
+
+.. php:namespace:: Example\Advanced
+
+.. php:enum:: Suit : string
+
+    In playing cards, a suit is one of the categories into which the cards of a
+    deck are divided.
+
+    .. php:case:: Hearts : 'H'
+    .. php:case:: Diamonds : 'D'
+    .. php:case:: Clubs : 'C'
+    .. php:case:: Spades : 'S'
+
+    .. php:method:: color() -> string
+
+        Returns "red" for hearts and diamonds, "black" for clubs and spades.
+
+    .. php:staticmethod:: values() -> string[]
+
+        Returns an array of the values of all the cases on this enum.
+
+    .. php:const:: Roses() : Hearts
+
+        An alias for :php:case:`Example\\Advanced\\Suit::Hearts`.
+
+    .. php:const:: Bells : Diamonds
+
+        An alias for :php:case:`Example\\Advanced\\Suit::Diamonds`.
+
+    .. php:const:: Acorns : Clubs
+
+        An alias for :php:case:`Example\\Advanced\\Suit::Clubs`.
+
+    .. php:const:: Shields : Spades
+
+        An alias for :php:case:`Example\\Advanced\\Suit::Spades`.
+
+Enumeration Links
+-----------------
+
+Links to Basic Enumeration Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:php:enum:`Example\\Basic\\Suit`
+
+:php:case:`Example\\Basic\\Suit::Hearts`
+
+:php:case:`Example\\Basic\\Suit::Diamonds`
+
+:php:case:`Example\\Basic\\Suit::Clubs`
+
+:php:case:`Example\\Basic\\Suit::Spades`
+
+Links to Backed Enumeration Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:php:enum:`Example\\Backed\\Suit`
+
+:php:case:`Example\\Backed\\Suit::Hearts`
+
+:php:case:`Example\\Backed\\Suit::Diamonds`
+
+:php:case:`Example\\Backed\\Suit::Clubs`
+
+:php:case:`Example\\Backed\\Suit::Spades`
+
+Links to Advanced Enumeration Example
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+:php:enum:`Example\\Advanced\\Suit`
+
+:php:case:`Example\\Advanced\\Suit::Hearts`
+
+:php:case:`Example\\Advanced\\Suit::Diamonds`
+
+:php:case:`Example\\Advanced\\Suit::Clubs`
+
+:php:case:`Example\\Advanced\\Suit::Spades`
+
+:php:meth:`Example\\Advanced\\Suit::color`
+
+:php:meth:`Example\\Advanced\\Suit::values`
+
+:php:const:`Example\\Advanced\\Suit::Roses`
+
+:php:const:`Example\\Advanced\\Suit::Bells`
+
+:php:const:`Example\\Advanced\\Suit::Acorns`
+
+:php:const:`Example\\Advanced\\Suit::Shields`


### PR DESCRIPTION
This PR adds support for [PHP enumerations](https://www.php.net/enum).

In general, the `:php:enum:` and `:php:case:` directives work just like `:php:class:` and `:php:const:`, respectively. However, to support [backed enums](https://www.php.net/manual/en/language.enumerations.backed.php), I got a little creative and introduced a minor new syntax to the signature line.

Here's a very simple, basic enum example:

```
.. php:enum:: Suit
    .. php:case:: Hearts
    .. php:case:: Diamonds
    .. php:case:: Clubs
    .. php:case:: Spades
```

Here's the same example as a backed enum:

```
.. php:enum:: Suit : string
    .. php:case:: Hearts : 'H'
    .. php:case:: Diamonds : 'D'
    .. php:case:: Clubs : 'C'
    .. php:case:: Spades : 'S'
```

This new syntax is effectively the same as this:

```
.. php:enum:: Suit() -> string
    .. php:case:: Hearts() -> 'H'
```

The use of `() ->`, however, is intended to convey method parameters and a return type, which isn't appropriate semantics for a backed enum type and case values, so I decided to introduce this new syntax.

When it renders, Sphinx displays it with the arrow symbol (→) as if it is a return type, but we don't have much choice, since we must use one of the methods from `sphinx.addnodes`, and I chose to use `desc_returns()`.

<img width="838" alt="Screen Shot 2022-08-10 at 19 36 54" src="https://user-images.githubusercontent.com/42941/184046992-295e7850-0e36-46b1-ba5c-d8d6de5508d3.png">

