### PR TITLE
Add contents entries for object & :nocontentsentry:

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -282,7 +282,7 @@ class PhpObject(ObjectDescription):
         if config.toc_object_entries_show_parents == 'hide':
             return name + parens
         if config.toc_object_entries_show_parents == 'all':
-            if objtype in {'method', 'const', 'attr', 'staticmethod', 'case'}:
+            if objtype in {'method', 'const', 'attr', 'staticmethod', 'case'} and len(parents) > 0:
                 name = parents.pop() + '::' + name
             return '\\'.join(parents + [name + parens])
         return ''

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -115,6 +115,7 @@ class PhpObject(ObjectDescription):
     """
     option_spec = {
         'noindex': directives.flag,
+        'nocontentsentry': directives.flag,
         'module': directives.unchanged,
     }
 
@@ -253,6 +254,38 @@ class PhpObject(ObjectDescription):
         elif enumtype:
             signode += addnodes.desc_returns(enumtype, enumtype)
         return fullname, name_prefix
+
+    def _object_hierarchy_parts(self, sig_node: addnodes.desc_signature):
+        if 'fullname' not in sig_node:
+            return ()
+        namespace = sig_node.get('namespace')
+        fullname = sig_node['fullname']
+
+        if isinstance(namespace, str):
+            return (namespace, *fullname.split('::'))
+        else:
+            return tuple(fullname.split('::'))
+
+    def _toc_entry_name(self, sig_node: addnodes.desc_signature) -> str:
+        if not sig_node.get('_toc_parts'):
+            return ''
+
+        config = self.env.app.config
+        objtype = sig_node.parent.get('objtype')
+        if config.add_function_parentheses and objtype in {'function', 'method'}:
+            parens = '()'
+        else:
+            parens = ''
+        *parents, name = sig_node['_toc_parts']
+        if config.toc_object_entries_show_parents == 'domain':
+            return sig_node.get('fullname', name) + parens
+        if config.toc_object_entries_show_parents == 'hide':
+            return name + parens
+        if config.toc_object_entries_show_parents == 'all':
+            if objtype in {'method', 'const', 'attr', 'staticmethod', 'case'}:
+                name = parents.pop() + '::' + name
+            return '\\'.join(parents + [name + parens])
+        return ''
 
     def get_index_text(self, modname, name):
         """


### PR DESCRIPTION
This allows to automatically add entries for domain objects in contents table with Sphinx >= 5.2.
See <https://github.com/sphinx-doc/sphinx/pull/10807> and <https://github.com/sphinx-doc/sphinx/pull/10886>


See also an example here with my (still small) documentation : https://status.club1.fr/sphinx-inventory-parser/index.html

(I didn't add the `php:namespace` in my docs as it caused issues with `:php:attr:` references for some reason, I will open an issue (and/or a PR) for this bug soon)

## No namespace

### `toc_object_entries_show_parents = hide`

![Screen Shot 2023-04-06 at 12 53 48](https://user-images.githubusercontent.com/23519418/230358441-89a4dc8c-0faa-45ec-a092-a869c3debbda.png)
![Screen Shot 2023-04-06 at 12 53 56](https://user-images.githubusercontent.com/23519418/230358437-5dd09bfb-872c-43a7-afa5-d996c4addf3e.png)

### `toc_object_entries_show_parents = domain`

![Screen Shot 2023-04-06 at 12 55 02](https://user-images.githubusercontent.com/23519418/230358435-4bd5bce1-75e8-4cf4-b475-909162e20a8e.png)
![Screen Shot 2023-04-06 at 12 55 08](https://user-images.githubusercontent.com/23519418/230358434-63232b8a-5f27-4302-9b58-0a7a89424871.png)

### `toc_object_entries_show_parents = all`

_Same results as `toc_object_entries_show_parents = domain`_

## With namespace

### `toc_object_entries_show_parents = hide`

![Screen Shot 2023-04-06 at 12 58 48](https://user-images.githubusercontent.com/23519418/230358424-6bb8c244-b4aa-46ff-885f-3bf91fb89ca4.png)
![Screen Shot 2023-04-06 at 12 58 52](https://user-images.githubusercontent.com/23519418/230358422-e2ad602a-8147-4af8-9ae1-4a492939ac82.png)

### `toc_object_entries_show_parents = domain`

![Screen Shot 2023-04-06 at 12 58 20](https://user-images.githubusercontent.com/23519418/230358428-90967af0-a77f-4b61-9da7-d7dc9e3dd3f5.png)
![Screen Shot 2023-04-06 at 12 58 30](https://user-images.githubusercontent.com/23519418/230358425-2e27045c-cde2-4f2f-a11c-9d58498a63c9.png)

### `toc_object_entries_show_parents = all`

![Screen Shot 2023-04-06 at 12 57 25](https://user-images.githubusercontent.com/23519418/230358431-64a87e73-c770-4e59-bea9-7f6faf1ab44c.png)
![Screen Shot 2023-04-06 at 12 57 33](https://user-images.githubusercontent.com/23519418/230358430-540b6ed1-5620-409c-ba42-439c8d30d6b6.png)

_the default theme does not support it very well :sweat_smile:_