### PR TITLE
Add GitHub action workflow to build & publish doc

### DIFF
--- a/.github/workflows/doc.yml
+++ b/.github/workflows/doc.yml
@@ -1,0 +1,51 @@
+name: Doc
+
+on:
+  # Runs on pushes targeting the default branch
+  push:
+    branches: [master]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
+# However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  # Build job
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install Python dependencies
+        run: pip install -r requirements.txt
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v3
+      - name: Build doc
+        run: make -C doc html
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: doc/_build/html
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,4 +1,4 @@
-.. include:: ../README
+.. include:: ../README.rst
 
 Contents:
 ---------


### PR DESCRIPTION
- Fix include directive error message:
  
      doc/index.rst:1: CRITICAL: Problems with "include" directive path:
      InputError: [Errno 2] No such file or directory: '../README'.
  
  This error may have appeared when upgrading the maximum Sphinx version.
- Add GitHub action workflow to build & publish doc

You will need to follow the steps (1) to (4) from [this GitHub doc](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow), then once merged the doc should be accessible at this URL: https://markstory.github.io/sphinxcontrib-phpdomain/

Fixes #45 