### PR TITLE
Fix prefix-less link generation for properties and classes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,6 @@ jobs:
         pip install -r requirements.txt
         pip install .
 
-    - name: Build Test
+    - name: Build test/
       run: |
         cd test && make html SPHINXOPTS='-W'

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -508,16 +508,15 @@ class PhpXRefRole(XRefRole):
             if title.startswith("::"):
                 title = title[2:]
             target = target.lstrip('~')  # only has a meaning for the title
-            # if the first character is a tilde, don't display the module/class
-            # parts of the contents
-            if title[0:1] == '~':
-                m = re.search(r"(?:.+[:]{2}|(?:.*?\\{2})+)?(.*)\Z", title)
+
+            # If the first char is ~ don't display the leading namespace & class.
+            if title.startswith('~'):
+                m = re.search(r"(?:.+[:]{2}|(?:.*?\\{1,2})+)?(.*)\Z", title)
                 if m:
                     title = m.group(1)
 
-        if not title.startswith("$"):
-            refnode['php:namespace'] = env.temp_data.get('php:namespace')
-            refnode['php:class'] = env.temp_data.get('php:class')
+        refnode['php:namespace'] = env.temp_data.get('php:namespace')
+        refnode['php:class'] = env.temp_data.get('php:class')
 
         return title, target
 

--- a/test/test_doc.rst
+++ b/test/test_doc.rst
@@ -168,13 +168,9 @@ Test Case - Global symbols with no namespaces
 
 :php:func:`DateTime::setDate()`
 
-:php:func:`~DateTime::setDate()` Should not be prefixed with a classname
-
 :php:func:`DateTime::ATOM`
 
 :php:func:`DateTime::$testattr`
-
-:php:func:`~DateTime::$testattr` Should not be prefixed with classname
 
 :php:func:`OtherClass::update`
 
@@ -202,10 +198,20 @@ Test Case - Global symbols with no namespaces
 
 :php:func:`LogTrait::log()`
 
-.. php:namespace:: LibraryName
+Test Case - Prefix less links
+-----------------------------
+
+The following links should not be prefixed with a classname.
+
+:php:func:`~DateTime::setDate()`
+
+:php:attr:`~DateTime::$testattr`
+
 
 Namespaced elements
 ===================
+
+.. php:namespace:: LibraryName
 
 .. php:function:: namespaced_function($one[, $two])
 
@@ -312,6 +318,8 @@ Namespaced elements
 Test Case - not including namespace
 -----------------------------------
 
+Within a namespace context you don't need to include the namespace in links.
+
 :php:ns:`LibraryName`
 
 :php:func:`namespaced_function()`
@@ -320,22 +328,13 @@ Test Case - not including namespace
 
 :php:class:`LibraryClass`
 
-:php:class:`~LibraryName\\LibraryClass` Should not be be prefixed with
-classname.
-
 :php:func:`LibraryClass::instanceMethod`
-
-:php:func:`~LibraryClass::instanceMethod` Should not be prefixed with classname.
 
 :php:func:`LibraryClass::staticMethod()`
 
 :php:attr:`LibraryClass::$property`
 
-:php:attr:`~LibraryClass::$property` Should not be prefixed with classname.
-
 :php:const:`LibraryClass::TEST_CONST`
-
-:php:const:`~LibraryClass::TEST_CONST` Should not be prefixed with classname.
 
 :php:class:`LibraryName\\OtherClass`
 
@@ -363,8 +362,6 @@ classname.
 
 :php:interface:`LibraryInterface`
 
-:php:interface:`~LibraryName\\LibraryInterface`
-
 :php:func:`LibraryInterface::instanceMethod`
 
 :php:exc:`NamespaceException`
@@ -374,6 +371,28 @@ classname.
 :php:trait:`LibraryName\\TemplateTrait`
 
 :php:func:`LibraryName\\TemplateTrait::render()`
+
+Test Case - Links with prefix trimming
+--------------------------------------
+
+All of the following links should not be prefixed with a namespace.
+
+:php:interface:`~LibraryName\\LibraryInterface`
+
+:php:class:`~LibraryName\\LibraryClass`
+
+:php:trait:`~LibraryName\\TemplateTrait`
+
+:php:exc:`~LibraryName\\NamespaceException`
+
+All of the following links should not be prefixed with a classname.
+
+:php:func:`~LibraryClass::instanceMethod`
+
+:php:const:`~LibraryClass::TEST_CONST`
+
+:php:attr:`~LibraryClass::$property`
+
 
 Test Case - global access
 -------------------------

--- a/test/test_doc.rst
+++ b/test/test_doc.rst
@@ -166,11 +166,15 @@ Test Case - Global symbols with no namespaces
 
 :php:func:`DateTime::getLastErrors()`
 
-:php:func:`~DateTime::setDate()`
+:php:func:`DateTime::setDate()`
+
+:php:func:`~DateTime::setDate()` Should not be prefixed with a classname
 
 :php:func:`DateTime::ATOM`
 
 :php:func:`DateTime::$testattr`
+
+:php:func:`~DateTime::$testattr` Should not be prefixed with classname
 
 :php:func:`OtherClass::update`
 
@@ -316,16 +320,22 @@ Test Case - not including namespace
 
 :php:class:`LibraryClass`
 
-
-:php:class:`~LibraryName\\LibraryClass`
+:php:class:`~LibraryName\\LibraryClass` Should not be be prefixed with
+classname.
 
 :php:func:`LibraryClass::instanceMethod`
+
+:php:func:`~LibraryClass::instanceMethod` Should not be prefixed with classname.
 
 :php:func:`LibraryClass::staticMethod()`
 
 :php:attr:`LibraryClass::$property`
 
+:php:attr:`~LibraryClass::$property` Should not be prefixed with classname.
+
 :php:const:`LibraryClass::TEST_CONST`
+
+:php:const:`~LibraryClass::TEST_CONST` Should not be prefixed with classname.
 
 :php:class:`LibraryName\\OtherClass`
 
@@ -377,6 +387,8 @@ Test Case - global access
 :php:const:`SOME_CONSTANT`
 
 :php:attr:`LibraryName\\LibraryClass::$property`
+
+:php:attr:`~LibraryName\\LibraryClass::$property` Should not be prefixed with classname.
 
 :php:const:`LibraryName\\LibraryClass::TEST_CONST`
 


### PR DESCRIPTION
Pull in the changes made my @n-peugnet and also fix prefix removal
on namespaced class links as they were wrong too.

Fixes #44