### PR TITLE
Support noindexentry option for domain objects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -78,11 +78,13 @@ Result
 -----------------
 
 .. php:class:: DateTime
+   :noindexentry:
    :nocontentsentry:
 
    Datetime class
 
    .. php:method:: setDate($year, $month, $day)
+      :noindexentry:
       :nocontentsentry:
 
       Set the date.
@@ -94,6 +96,7 @@ Result
 
 
    .. php:method:: setTime($hour, $minute[, $second])
+      :noindexentry:
       :nocontentsentry:
 
       Set the time.
@@ -104,6 +107,7 @@ Result
       :returns: Either false on failure, or the DateTime object for method chaining.
 
    .. php:const:: ATOM
+      :noindexentry:
       :nocontentsentry:
 
       Y-m-d\TH:i:sP

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -115,6 +115,7 @@ class PhpObject(ObjectDescription):
     """
     option_spec = {
         'noindex': directives.flag,
+        'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
         'module': directives.unchanged,
     }
@@ -328,10 +329,11 @@ class PhpObject(ObjectDescription):
                     line=self.lineno)
             objects[fullname] = (self.env.docname, self.objtype)
 
-        indextext = self.get_index_text(modname, name_cls)
-        if indextext:
-            self.indexnode['entries'].append(('single', indextext,
-                                              fullname, fullname, None))
+        if 'noindexentry' not in self.options:
+            indextext = self.get_index_text(modname, name_cls)
+            if indextext:
+                self.indexnode['entries'].append(('single', indextext,
+                                                  fullname, fullname, None))
 
 
 class PhpGloballevel(PhpObject):


### PR DESCRIPTION
This option allows to disable the creation of index entries for targeted objects. See <https://www.sphinx-doc.org/en/master/usage/restructuredtext/domains.html#basic-markup>

Inspired from [this change](https://github.com/sphinx-doc/sphinx/pull/10807/commits/3a4778f158a765e0c6745075778d6c971b390c7b#diff-4440aa368513769284c3d18efa39fc65c05f3f7ed3deeabbc2f2def311ae7e2b).