### PR TITLE
Cleanup doc (nocontentsentry, indentation, rst xrefs)

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,9 +49,9 @@ This is source::
 
   .. php:class:: DateTime
 
-    Datetime class
+     Datetime class
 
-    .. php:method:: setDate($year, $month, $day)
+     .. php:method:: setDate($year, $month, $day)
 
         Set the date.
 
@@ -61,7 +61,7 @@ This is source::
         :returns: Either false on failure, or the datetime object for method chaining.
 
 
-    .. php:method:: setTime($hour, $minute[, $second])
+     .. php:method:: setTime($hour, $minute[, $second])
 
         Set the time.
 
@@ -70,7 +70,7 @@ This is source::
         :param int $second: The second
         :returns: Either false on failure, or the datetime object for method chaining.
 
-    .. php:const:: ATOM
+     .. php:const:: ATOM
 
         Y-m-d\TH:i:sP
 
@@ -78,10 +78,12 @@ Result
 -----------------
 
 .. php:class:: DateTime
+   :nocontentsentry:
 
-  Datetime class
+   Datetime class
 
-  .. php:method:: setDate($year, $month, $day)
+   .. php:method:: setDate($year, $month, $day)
+      :nocontentsentry:
 
       Set the date.
 
@@ -91,7 +93,8 @@ Result
       :returns: Either false on failure, or the DateTime object for method chaining.
 
 
-  .. php:method:: setTime($hour, $minute[, $second])
+   .. php:method:: setTime($hour, $minute[, $second])
+      :nocontentsentry:
 
       Set the time.
 
@@ -100,7 +103,8 @@ Result
       :param int $second: The second
       :returns: Either false on failure, or the DateTime object for method chaining.
 
-  .. php:const:: ATOM
+   .. php:const:: ATOM
+      :nocontentsentry:
 
       Y-m-d\TH:i:sP
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -132,9 +132,9 @@ Each directive populates the index, and or the namespace index.
             Text about the method
         
 
-   .. seealso:: .. php:method:: name
-                .. php:attr:: name
-                .. php:const:: name
+   .. seealso:: :rst:dir:`php:method`
+                :rst:dir:`php:attr`
+                :rst:dir:`php:const`
 
 .. rst:directive:: .. php:method:: name(signature)
 


### PR DESCRIPTION
- Fix indentation in "Quick Sample".
- Add :nocontentsentry: option to "Quick Sample" example to prevent polluting the table of contents.
- Use real rst cross-references with :rst:dir: role.


### Before
![Screen Shot 2023-04-10 at 11 39 25](https://user-images.githubusercontent.com/23519418/230876781-5865c9e6-b207-45b9-8ca6-aeb8dbb999f0.png)

### After
![Screen Shot 2023-04-10 at 11 38 30](https://user-images.githubusercontent.com/23519418/230876787-90714825-da96-4bd0-bfff-34ab1bbae113.png)

### Before
![Screen Shot 2023-04-10 at 11 39 04](https://user-images.githubusercontent.com/23519418/230876785-432131fb-5506-4147-a410-6279c464b0d3.png)

### After
![Screen Shot 2023-04-10 at 11 37 50](https://user-images.githubusercontent.com/23519418/230876789-03ab0dce-9125-4279-8f60-78609bc1ed6a.png)