### PR TITLE
Reorganise documentation & usage example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,93 +36,15 @@ PHP Domain supports following objects:
 
         Package\Subpackage\Class
 
+See `Usage Example`_ in the documentation for information about how to use it.
+
+.. _`Usage Example`: https://markstory.github.io/sphinxcontrib-phpdomain/usage.html
+
 URLs
 ====
 
 :PyPI: https://pypi.python.org/pypi/sphinxcontrib-phpdomain
 :Documentation: https://markstory.github.io/sphinxcontrib-phpdomain/
-
-Quick Sample
-============
-
-This is source:
-
-.. code:: rst
-
-  .. php:class:: DateTime
-
-     Datetime class
-
-     .. php:method:: setDate($year, $month, $day)
-
-        Set the date.
-
-        :param int $year: The year.
-        :param int $month: The month.
-        :param int $day: The day.
-        :returns: Either false on failure, or the datetime object for method chaining.
-
-
-     .. php:method:: setTime($hour, $minute[, $second])
-
-        Set the time.
-
-        :param int $hour: The hour
-        :param int $minute: The minute
-        :param int $second: The second
-        :returns: Either false on failure, or the datetime object for method chaining.
-
-     .. php:const:: ATOM
-
-        Y-m-d\TH:i:sP
-
-Result
------------------
-
-.. php:class:: DateTime
-   :nocontentsentry:
-
-   Datetime class
-
-   .. php:method:: setDate($year, $month, $day)
-      :nocontentsentry:
-
-      Set the date.
-
-      :param int $year: The year.
-      :param int $month: The month.
-      :param int $day: The day.
-      :returns: Either false on failure, or the DateTime object for method chaining.
-
-
-   .. php:method:: setTime($hour, $minute[, $second])
-      :nocontentsentry:
-
-      Set the time.
-
-      :param int $hour: The hour
-      :param int $minute: The minute
-      :param int $second: The second
-      :returns: Either false on failure, or the DateTime object for method chaining.
-
-   .. php:const:: ATOM
-      :nocontentsentry:
-
-      Y-m-d\TH:i:sP
-
-Cross referencing
------------------
-
-From other place, you can create cross reference like that:
-
-.. code:: rst
-
-   You can modify a DateTime's date using :php:meth:`DateTime::setDate`.
-
-Result
------------
-
-You can modify a DateTime's date using :php:meth:`DateTime::setDate`.
 
 Install
 =======

--- a/doc/changes.rst
+++ b/doc/changes.rst
@@ -1,0 +1,6 @@
+ChangeLog
+#########
+
+.. include:: ../CHANGES
+
+

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -1,18 +1,15 @@
 .. include:: ../README.rst
 
-Contents:
----------
+Contents
+========
 
 .. toctree::
    :maxdepth: 2
 
+   usage
    reference
+   changes
 
 * :ref:`genindex`
 * :ref:`search`
-
-ChangeLog
-=========
-
-.. include:: ../CHANGES
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -1,0 +1,82 @@
+Usage Example
+=============
+
+This is source:
+
+.. code:: rst
+
+  .. php:class:: DateTime
+
+     Datetime class
+
+     .. php:method:: setDate($year, $month, $day)
+
+        Set the date.
+
+        :param int $year: The year.
+        :param int $month: The month.
+        :param int $day: The day.
+        :returns: Either false on failure, or the datetime object for method chaining.
+
+
+     .. php:method:: setTime($hour, $minute[, $second])
+
+        Set the time.
+
+        :param int $hour: The hour
+        :param int $minute: The minute
+        :param int $second: The second
+        :returns: Either false on failure, or the datetime object for method chaining.
+
+     .. php:const:: ATOM
+
+        Y-m-d\TH:i:sP
+
+Result
+-----------------
+
+.. php:class:: DateTime
+   :nocontentsentry:
+
+   Datetime class
+
+   .. php:method:: setDate($year, $month, $day)
+      :nocontentsentry:
+
+      Set the date.
+
+      :param int $year: The year.
+      :param int $month: The month.
+      :param int $day: The day.
+      :returns: Either false on failure, or the DateTime object for method chaining.
+
+
+   .. php:method:: setTime($hour, $minute[, $second])
+      :nocontentsentry:
+
+      Set the time.
+
+      :param int $hour: The hour
+      :param int $minute: The minute
+      :param int $second: The second
+      :returns: Either false on failure, or the DateTime object for method chaining.
+
+   .. php:const:: ATOM
+      :nocontentsentry:
+
+      Y-m-d\TH:i:sP
+
+Cross referencing
+-----------------
+
+From other place, you can create cross reference like that:
+
+.. code:: rst
+
+   You can modify a DateTime's date using :php:meth:`DateTime::setDate`.
+
+Result
+-----------
+
+You can modify a DateTime's date using :php:meth:`DateTime::setDate`.
+


### PR DESCRIPTION
- Move Quick Sample into its own usage.rst page of the doc, as it is only correctly rendered in a Sphinx documentation.
- Move Changelog inclusion into its own page of the doc, as its growing size took a lot of space in the home page.

These two changes leave a lot more room for the table of contents, as it was quite buried in the home page before.

Fixes #41

![Screen Shot 2023-04-13 at 21 54 57](https://user-images.githubusercontent.com/23519418/231874789-5a410b3c-2383-4846-8775-fdf75ad2f7c4.png)

