### PR TITLE
Adding visibility to class members and abstract/final to classes

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -391,9 +391,6 @@ class PhpClasslike(PhpObject):
         'noindexentry': directives.flag,
         'nocontentsentry': directives.flag,
         'module': directives.unchanged,
-        'private': directives.flag,
-        'public': directives.flag,
-        'protected': directives.flag,
         'final': directives.flag,
         'abstract': directives.flag
     }
@@ -401,15 +398,9 @@ class PhpClasslike(PhpObject):
     def get_signature_prefix(self, sig):
         prefix = ''
         if 'final' in self.options:
-            prefix += _('final ')
+            prefix += 'final '
         elif self.objtype == 'class' and 'abstract' in self.options:
-            prefix += _('abstract')
-        if 'private' in self.options:
-            prefix += _('private ')
-        elif 'protected' in self.options:
-            prefix += _('protected')
-        elif 'public' in self.options:
-            prefix += _('public ')
+            prefix += 'abstract '
         return prefix + self.objtype + ' '
 
     def get_index_text(self, modname, name_cls):
@@ -465,17 +456,17 @@ class PhpClassmember(PhpObject):
         if self.objtype != 'case':
             if self.objtype == 'method':
                 if 'final' in self.options:
-                    prefix += _('final ')
+                    prefix += 'final '
                 elif 'abstract' in self.options:
-                    prefix += _('abstract ')
+                    prefix += 'abstract '
             if 'private' in self.options:
-                prefix += _('private ')
+                prefix += 'private '
             elif 'protected' in self.options:
-                prefix += _('protected ')
+                prefix += 'protected '
             elif 'public' in self.options:
-                prefix += _('public ')
+                prefix += 'public '
             if 'static' in self.options or self.objtype == 'staticmethod':
-                prefix += _('static ')
+                prefix += 'static '
         if self.objtype == 'attr':
             prefix += _('property ')
         if self.objtype == 'case':

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -386,8 +386,31 @@ class PhpClasslike(PhpObject):
     (classes, exceptions, interfaces, traits, enums).
     """
 
+    option_spec = {
+        'noindex': directives.flag,
+        'noindexentry': directives.flag,
+        'nocontentsentry': directives.flag,
+        'module': directives.unchanged,
+        'private': directives.flag,
+        'public': directives.flag,
+        'protected': directives.flag,
+        'final': directives.flag,
+        'abstract': directives.flag
+    }
+
     def get_signature_prefix(self, sig):
-        return self.objtype + ' '
+        prefix = ''
+        if 'final' in self.options:
+            prefix += _('final ')
+        elif self.objtype == 'class' and 'abstract' in self.options:
+            prefix += _('abstract')
+        if 'private' in self.options:
+            prefix += _('private ')
+        elif 'protected' in self.options:
+            prefix += _('protected')
+        elif 'public' in self.options:
+            prefix += _('public ')
+        return prefix + self.objtype + ' '
 
     def get_index_text(self, modname, name_cls):
         if self.objtype == 'class':
@@ -425,14 +448,39 @@ class PhpClassmember(PhpObject):
     Description of a class member (methods, attributes).
     """
 
+    option_spec = {
+        'noindex': directives.flag,
+        'noindexentry': directives.flag,
+        'nocontentsentry': directives.flag,
+        'module': directives.unchanged,
+        'private': directives.flag,
+        'public': directives.flag,
+        'protected': directives.flag,
+        'static': directives.flag,
+        'final': directives.flag
+    }
+
     def get_signature_prefix(self, sig):
+        prefix = ''
+        if self.objtype != 'case':
+            if self.objtype == 'method':
+                if 'final' in self.options:
+                    prefix += _('final ')
+                elif 'abstract' in self.options:
+                    prefix += _('abstract ')
+            if 'private' in self.options:
+                prefix += _('private ')
+            elif 'protected' in self.options:
+                prefix += _('protected ')
+            elif 'public' in self.options:
+                prefix += _('public ')
+            if 'static' in self.options or self.objtype == 'staticmethod':
+                prefix += _('static ')
         if self.objtype == 'attr':
-            return _('property ')
-        if self.objtype == 'staticmethod':
-            return _('static ')
+            prefix += _('property ')
         if self.objtype == 'case':
-            return _('case ')
-        return ''
+            prefix += _('case ')
+        return prefix
 
     def needs_arglist(self):
         return self.objtype == 'method'


### PR DESCRIPTION
Hi,

I'm planning to work on an autodoc plugin for PHP using a method similar to [sphinx_jss](https://github.com/mozilla/sphinx-js), which means I'll rely on phpDocumentor to parse the docblocks into xml and then use sphinx to parse the XML into rst.

I found that the abstact/final keywords were not present for class-like structures, and that the visibility of class members wasn't implemented as well. This PR aims to correct this while staying backwards compatible.

I'm not familiar with how you want to test this, so please tell me if I've done something wrong during my commits.

Thanks in advance for your review.