### PR TITLE
Use native php naming

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -28,10 +28,10 @@ PHP Domain supports following objects:
 
 .. note::
 
-   This domain expresses methods and attribute names like this::
+   This domain expresses methods and properties like this::
 
       Class::method_name
-      Class::$attribute_name
+      Class::$prop_name
 
    You address classes/functions in namespaces using \\ syntax as you would in PHP::
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -103,7 +103,7 @@ Each directive populates the index, and or the namespace index.
 
 .. rst:directive:: .. php:class:: name
 
-   Describes a class.  Methods, attributes, and constants belonging to the class
+   Describes a class.  Methods, properties, and constants belonging to the class
    should be inside this directive's body::
 
         .. php:class:: MyClass
@@ -115,7 +115,7 @@ Each directive populates the index, and or the namespace index.
            Method description
 
 
-   Attributes, methods and constants don't need to be nested.  They can also just 
+   Properties, methods and constants don't need to be nested.  They can also just 
    follow the class declaration::
 
         .. php:class:: MyClass
@@ -128,7 +128,7 @@ Each directive populates the index, and or the namespace index.
         
 
    .. seealso:: :rst:dir:`php:method`
-                :rst:dir:`php:attr`
+                :rst:dir:`php:property`
                 :rst:dir:`php:const`
 
 .. rst:directive:: .. php:method:: name(signature)
@@ -145,9 +145,9 @@ Each directive populates the index, and or the namespace index.
         
            This is an instance method.
 
-.. rst:directive:: .. php:attr:: name
+.. rst:directive:: .. php:property:: name
 
-   Describe an property/attribute on a class.
+   Describe a property on a class.
 
 Cross Referencing
 =================
@@ -192,11 +192,11 @@ matching directive is found:
    
      :php:method:`DateTime::setDate`
 
-.. rst:role:: php:attr
+.. rst:role:: php:property
 
    Reference a property on an object::
    
-      :php:attr:`ClassName::$propertyName`
+      :php:property:`ClassName::$propertyName`
 
 .. rst:role:: php:interface
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -162,7 +162,7 @@ matching directive is found:
    
       .. php:namespace:`LibraryName\\SubPackage` will work correctly.
 
-.. rst:role:: php:func
+.. rst:role:: php:function
 
    Reference a PHP function either in a namespace or out. If the function is in
    a namespace, be sure to include the namespace, unless you are currently 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -34,11 +34,6 @@ Each directive populates the index, and or the namespace index.
 
    This directive declares a new PHP constant, you can also used it nested 
    inside a class directive to create class constants.
-   
-.. rst:directive:: .. php:exception:: name
-
-   This directive declares a new Exception in the current namespace. The 
-   signature can include constructor arguments.
 
 .. rst:directive:: .. php:interface:: name
 
@@ -202,10 +197,6 @@ matching directive is found:
    Reference a property on an object::
    
       :php:attr:`ClassName::$propertyName`
-
-.. rst:role:: php:exc
-
-   Reference an exception.  A namespaced name may be used.
 
 .. rst:role:: php:interface
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -150,11 +150,6 @@ Each directive populates the index, and or the namespace index.
         
            This is an instance method.
 
-.. rst:directive:: .. php:staticmethod:: ClassName::methodName(signature)
-
-    Describe a static method, its arguments, return value and exceptions,
-    see :rst:dir:`php:method` for options.
-
 .. rst:directive:: .. php:attr:: name
 
    Describe an property/attribute on a class.
@@ -198,11 +193,9 @@ matching directive is found:
 
 .. rst:role:: php:meth
 
-   Reference a method of a class/interface/trait. This role supports
-   both kinds of methods::
+   Reference a method of a class/interface/trait::
    
      :php:meth:`DateTime::setDate`
-     :php:meth:`Classname::staticMethod`
 
 .. rst:role:: php:attr
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -155,12 +155,12 @@ Cross Referencing
 The following roles refer to php objects and are links are generated if a 
 matching directive is found:
 
-.. rst:role:: php:ns
+.. rst:role:: php:namespace
 
    Reference a namespace. Nested namespaces need to be separated by two \\ due 
    to the syntax of ReST::
    
-      .. php:ns:`LibraryName\\SubPackage` will work correctly.
+      .. php:namespace:`LibraryName\\SubPackage` will work correctly.
 
 .. rst:role:: php:func
 

--- a/doc/reference.rst
+++ b/doc/reference.rst
@@ -186,11 +186,11 @@ matching directive is found:
    
      :php:class:`LibraryName\\ClassName`
 
-.. rst:role:: php:meth
+.. rst:role:: php:method
 
    Reference a method of a class/interface/trait::
    
-     :php:meth:`DateTime::setDate`
+     :php:method:`DateTime::setDate`
 
 .. rst:role:: php:attr
 

--- a/doc/usage.rst
+++ b/doc/usage.rst
@@ -73,10 +73,10 @@ From other place, you can create cross reference like that:
 
 .. code:: rst
 
-   You can modify a DateTime's date using :php:meth:`DateTime::setDate`.
+   You can modify a DateTime's date using :php:method:`DateTime::setDate`.
 
 Result
 -----------
 
-You can modify a DateTime's date using :php:meth:`DateTime::setDate`.
+You can modify a DateTime's date using :php:method:`DateTime::setDate`.
 

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -766,7 +766,7 @@ class PhpDomain(Domain):
         "const": PhpNamespacelevel,
         "class": PhpClasslike,
         "method": PhpClassmember,
-        "staticmethod": PhpClassmember,
+        "staticmethod": PhpClassmember,  # deprecated, use "method" with "static" modifier, methods in PHP are exclusively static or non-static
         "attr": PhpClassmember,
         "case": PhpClassmember,
         "exception": PhpClasslike,

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -746,7 +746,7 @@ class PhpDomain(Domain):
     name = "php"
     label = "PHP"
     object_types = {
-        "function": ObjType(_("function"), "func", "obj"),
+        "function": ObjType(_("function"), "function", "obj"),
         "global": ObjType(_("global variable"), "global", "obj"),
         "const": ObjType(_("const"), "const", "obj"),
         "method": ObjType(_("method"), "meth", "obj"),
@@ -779,7 +779,8 @@ class PhpDomain(Domain):
     }
 
     roles = {
-        "func": PhpXRefRole(fix_parens=False),
+        "function": PhpXRefRole(fix_parens=False),
+        "func": PhpXRefRole(fix_parens=False),  # deprecated, use "function"
         "global": PhpXRefRole(),
         "class": PhpXRefRole(),
         "exc": PhpXRefRole(),

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -753,7 +753,7 @@ class PhpDomain(Domain):
         "class": ObjType(_("class"), "class", "obj"),
         "attr": ObjType(_("attribute"), "attr", "obj"),
         "exception": ObjType(_("exception"), "exc", "obj"),
-        "namespace": ObjType(_("namespace"), "ns", "obj"),
+        "namespace": ObjType(_("namespace"), "namespace", "obj"),
         "interface": ObjType(_("interface"), "interface", "obj"),
         "trait": ObjType(_("trait"), "trait", "obj"),
         "enum": ObjType(_("enum"), "enum", "obj"),
@@ -786,7 +786,8 @@ class PhpDomain(Domain):
         "meth": PhpXRefRole(fix_parens=False),
         "attr": PhpXRefRole(),
         "const": PhpXRefRole(),
-        "ns": PhpXRefRole(),
+        "namespace": PhpXRefRole(),
+        "ns": PhpXRefRole(),  # deprecated, use "namespace"
         "obj": PhpXRefRole(),
         "interface": PhpXRefRole(),
         "trait": PhpXRefRole(),
@@ -828,7 +829,12 @@ class PhpDomain(Domain):
         return []
 
     def resolve_xref(self, env, fromdocname, builder, typ, target, node, contnode):
-        if typ == "ns" or typ == "obj" and target in self.data["namespaces"]:
+        if (
+            typ == "namespace"
+            or typ == "ns"
+            or typ == "obj"
+            and target in self.data["namespaces"]
+        ):
             docname, synopsis, deprecated = self.data["namespaces"].get(
                 target, ("", "", "")
             )

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -774,7 +774,7 @@ class PhpDomain(Domain):
         "trait": PhpClasslike,
         "enum": PhpClasslike,
         "namespace": PhpNamespace,
-        "currentmodule": PhpCurrentNamespace,
+        "currentmodule": PhpCurrentNamespace,  # deprecated, use "currentnamespace"
         "currentnamespace": PhpCurrentNamespace,
     }
 

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -749,7 +749,7 @@ class PhpDomain(Domain):
         "function": ObjType(_("function"), "function", "obj"),
         "global": ObjType(_("global variable"), "global", "obj"),
         "const": ObjType(_("const"), "const", "obj"),
-        "method": ObjType(_("method"), "meth", "obj"),
+        "method": ObjType(_("method"), "method", "obj"),
         "class": ObjType(_("class"), "class", "obj"),
         "attr": ObjType(_("attribute"), "attr", "obj"),
         "exception": ObjType(_("exception"), "exc", "obj"),
@@ -784,7 +784,8 @@ class PhpDomain(Domain):
         "global": PhpXRefRole(),
         "class": PhpXRefRole(),
         "exc": PhpXRefRole(),
-        "meth": PhpXRefRole(fix_parens=False),
+        "method": PhpXRefRole(fix_parens=False),
+        "meth": PhpXRefRole(fix_parens=False),  # deprecated, use "method"
         "attr": PhpXRefRole(),
         "const": PhpXRefRole(),
         "namespace": PhpXRefRole(),

--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -769,7 +769,7 @@ class PhpDomain(Domain):
         "staticmethod": PhpClassmember,  # deprecated, use "method" with "static" modifier, methods in PHP are exclusively static or non-static
         "attr": PhpClassmember,
         "case": PhpClassmember,
-        "exception": PhpClasslike,
+        "exception": PhpClasslike,  # deprecated, use "class", exceptions in PHP are regular classes
         "interface": PhpClasslike,
         "trait": PhpClasslike,
         "enum": PhpClasslike,

--- a/test/log.html
+++ b/test/log.html
@@ -48,7 +48,7 @@
       </li>
       <li>
         <p>
-          <code class="xref php php-meth docutils literal notranslate">
+          <code class="xref php php-method docutils literal notranslate">
             <span class="pre">Foo\A::simplifyy</span>
           </code>
         </p>
@@ -59,7 +59,7 @@
       <li>
         <p>
           <a class="reference internal" href="ns.html#Foo\A::simplify" title="Foo\A::simplify">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">Foo\A::simplify</span>
             </code>
           </a>
@@ -71,7 +71,7 @@
       <li>
         <p>
           <a class="reference internal" href="ns.html#Foo\A::simplify" title="Foo\A::simplify">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">Foo\A::simplify</span>
             </code>
           </a>

--- a/test/log.html
+++ b/test/log.html
@@ -3,6 +3,28 @@
   <section id="invalid-domain-type">
     <h1>Invalid domain type<a class="headerlink" href="#invalid-domain-type" title="Permalink to this heading">&#xB6;</a></h1>
   </section>
+  <section id="in-class-type-without-class">
+    <h1>In-class type without class<a class="headerlink" href="#in-class-type-without-class" title="Permalink to this heading">&#xB6;</a></h1>
+    <dl class="php method">
+      <dt class="sig sig-object php">
+        <span class="sig-name descname">
+          <span class="pre">x()</span>
+        </span>
+      </dt>
+      <dd/>
+    </dl>
+  </section>
+  <section id="not-in-class-type-with-class">
+    <h1>Not In-class type with class<a class="headerlink" href="#not-in-class-type-with-class" title="Permalink to this heading">&#xB6;</a></h1>
+    <dl class="php class">
+      <dt class="sig sig-object php">
+        <span class="sig-name descname">
+          <span class="pre">A::A</span>
+        </span>
+      </dt>
+      <dd/>
+    </dl>
+  </section>
   <section id="invalid-signature">
     <h1>Invalid signature<a class="headerlink" href="#invalid-signature" title="Permalink to this heading">&#xB6;</a></h1>
     <dl class="php method">

--- a/test/log.md
+++ b/test/log.md
@@ -3,6 +3,16 @@
 :::{php:namespacee} Foo
 :::
 
+# In-class type without class
+
+:::{php:method} x()
+:::
+
+# Not In-class type with class
+
+:::{php:class} A::A
+:::
+
 # Invalid signature
 
 :::{php:method} x();

--- a/test/log.md
+++ b/test/log.md
@@ -22,14 +22,14 @@
 
 - {php:class}`Foo\Aa`
 
-- {php:meth}`Foo\A::simplifyy`
+- {php:method}`Foo\A::simplifyy`
 
 :::{php:namespace} Foo
 :::
 
-- {php:meth}`Foo\A::simplify`
+- {php:method}`Foo\A::simplify`
 
 :::{php:namespace} Fooo
 :::
 
-- {php:meth}`Foo\A::simplify`
+- {php:method}`Foo\A::simplify`

--- a/test/log.txt
+++ b/test/log.txt
@@ -9,7 +9,7 @@ test/log.md:35: [phpdomain] Target Fooo\Foo\A::simplify not found - did you mean
 test/ns.md:59: [phpdomain] Target A::simplify not found
 test/ns.md:69: [phpdomain] Target A2::simplify not found
 test/ns.md:74: [phpdomain] Target Bar2\A::simplify not found
-test/rst_doc.md:470: [phpdomain] Target OtherLibrary\int|string|ReturnedClass|\LibraryName\SubPackage\SubpackageInterface|null not found
+test/rst_doc.md:468: [phpdomain] Target OtherLibrary\int|string|ReturnedClass|\LibraryName\SubPackage\SubpackageInterface|null not found
 test/rst_doc2.md:11: [phpdomain] Target Imagine\Image\ImageInterface::draw not found
 test/rst_doc2.md:17: [phpdomain] Target Imagine\Image\PointInterface not found
 test/rst_doc2.md:17: [phpdomain] Target Imagine\Image\BoxInterface not found

--- a/test/log.txt
+++ b/test/log.txt
@@ -9,7 +9,7 @@ test/log.md:35: [phpdomain] Target Fooo\Foo\A::simplify not found - did you mean
 test/ns.md:59: [phpdomain] Target A::simplify not found
 test/ns.md:69: [phpdomain] Target A2::simplify not found
 test/ns.md:74: [phpdomain] Target Bar2\A::simplify not found
-test/rst_doc.md:506: [phpdomain] Target OtherLibrary\int|string|ReturnedClass|\LibraryName\SubPackage\SubpackageInterface|null not found
+test/rst_doc.md:502: [phpdomain] Target OtherLibrary\int|string|ReturnedClass|\LibraryName\SubPackage\SubpackageInterface|null not found
 test/rst_doc2.md:11: [phpdomain] Target Imagine\Image\ImageInterface::draw not found
 test/rst_doc2.md:17: [phpdomain] Target Imagine\Image\PointInterface not found
 test/rst_doc2.md:17: [phpdomain] Target Imagine\Image\BoxInterface not found

--- a/test/log.txt
+++ b/test/log.txt
@@ -9,7 +9,7 @@ test/log.md:35: [phpdomain] Target Fooo\Foo\A::simplify not found - did you mean
 test/ns.md:59: [phpdomain] Target A::simplify not found
 test/ns.md:69: [phpdomain] Target A2::simplify not found
 test/ns.md:74: [phpdomain] Target Bar2\A::simplify not found
-test/rst_doc.md:502: [phpdomain] Target OtherLibrary\int|string|ReturnedClass|\LibraryName\SubPackage\SubpackageInterface|null not found
+test/rst_doc.md:470: [phpdomain] Target OtherLibrary\int|string|ReturnedClass|\LibraryName\SubPackage\SubpackageInterface|null not found
 test/rst_doc2.md:11: [phpdomain] Target Imagine\Image\ImageInterface::draw not found
 test/rst_doc2.md:17: [phpdomain] Target Imagine\Image\PointInterface not found
 test/rst_doc2.md:17: [phpdomain] Target Imagine\Image\BoxInterface not found

--- a/test/log.txt
+++ b/test/log.txt
@@ -1,11 +1,14 @@
 test/log.md:3: WARNING: Unknown directive type: 'php:namespacee' [myst.directive_unknown]
-test/log.md:8: WARNING: [phpdomain] Invalid signature
-test/log.md:13: [phpdomain] Target Foo\Aa not found
-test/log.md:15: [phpdomain] Target Foo\A::simplifyy not found
-test/log.md:20: [phpdomain] Target Foo\Foo\A::simplify not found - did you mean to write A::simplify?
-test/log.md:25: [phpdomain] Target Fooo\Foo\A::simplify not found - did you mean to write \Foo\A::simplify?
-test/ns.md:48: [phpdomain] Target A2::simplify not found
-test/ns.md:53: [phpdomain] Target Bar2\A::simplify not found
+test/log.md:8: WARNING: [phpdomain] In-class type requires class
+test/log.md:13: WARNING: [phpdomain] Unexpected name in non in-class type
+test/log.md:18: WARNING: [phpdomain] Invalid signature
+test/log.md:23: [phpdomain] Target Foo\Aa not found
+test/log.md:25: [phpdomain] Target Foo\A::simplifyy not found
+test/log.md:30: [phpdomain] Target Foo\Foo\A::simplify not found - did you mean to write A::simplify?
+test/log.md:35: [phpdomain] Target Fooo\Foo\A::simplify not found - did you mean to write \Foo\A::simplify?
+test/ns.md:59: [phpdomain] Target A::simplify not found
+test/ns.md:69: [phpdomain] Target A2::simplify not found
+test/ns.md:74: [phpdomain] Target Bar2\A::simplify not found
 test/rst_doc.md:506: [phpdomain] Target OtherLibrary\int|string|ReturnedClass|\LibraryName\SubPackage\SubpackageInterface|null not found
 test/rst_doc2.md:11: [phpdomain] Target Imagine\Image\ImageInterface::draw not found
 test/rst_doc2.md:17: [phpdomain] Target Imagine\Image\PointInterface not found

--- a/test/method.html
+++ b/test/method.html
@@ -36,7 +36,7 @@
         <li>
           <p>
             <a class="reference internal" href="#Foo::test" title="Foo::test">
-              <code class="xref php php-meth docutils literal notranslate">
+              <code class="xref php php-method docutils literal notranslate">
                 <span class="pre">Foo::test()</span>
               </code>
             </a>

--- a/test/method.md
+++ b/test/method.md
@@ -14,4 +14,4 @@ Simple test method.
 
 ## Cross linking
 
-- {php:meth}`Foo::test()`
+- {php:method}`Foo::test()`

--- a/test/ns.html
+++ b/test/ns.html
@@ -142,6 +142,104 @@
       </ul>
     </section>
   </section>
+  <section id="leading-implies-absolute-class-name">
+    <h1>Leading <code class="docutils literal notranslate"><span class="pre">\</span></code> implies absolute class name<a class="headerlink" href="#leading-implies-absolute-class-name" title="Permalink to this heading">&#xB6;</a></h1>
+    <dl class="php class">
+      <dt class="sig sig-object php">
+        <em class="property">
+          <span class="pre">class</span>
+        </em>
+        <span class="sig-prename descclassname">
+          <span class="pre">Bar\</span>
+        </span>
+        <span class="sig-name descname">
+          <span class="pre">A</span>
+        </span>
+      </dt>
+      <dd/>
+    </dl>
+    <dl class="php method">
+      <dt class="sig sig-object php">
+        <span class="sig-prename descclassname">
+          <span class="pre">Bar\A::</span>
+        </span>
+        <span class="sig-name descname">
+          <span class="pre">simplify</span>
+        </span>
+        <span class="sig-paren">(</span>
+        <span class="sig-paren">)</span>
+      </dt>
+      <dd/>
+    </dl>
+    <dl class="php class">
+      <dt class="sig sig-object php" id="Bar\A2">
+        <em class="property">
+          <span class="pre">class</span>
+        </em>
+        <span class="sig-prename descclassname">
+          <span class="pre">Bar\</span>
+        </span>
+        <span class="sig-name descname">
+          <span class="pre">A2</span>
+        </span>
+        <a class="headerlink" href="#Bar\A2" title="Permalink to this definition">&#xB6;</a>
+      </dt>
+      <dd/>
+    </dl>
+    <dl class="php method">
+      <dt class="sig sig-object php" id="Bar\A2::simplify">
+        <span class="sig-prename descclassname">
+          <span class="pre">Bar\A2::</span>
+        </span>
+        <span class="sig-name descname">
+          <span class="pre">simplify</span>
+        </span>
+        <span class="sig-paren">(</span>
+        <span class="sig-paren">)</span>
+        <a class="headerlink" href="#Bar\A2::simplify" title="Permalink to this definition">&#xB6;</a>
+      </dt>
+      <dd/>
+    </dl>
+    <section id="id2">
+      <h2>Cross linking<a class="headerlink" href="#id2" title="Permalink to this heading">&#xB6;</a></h2>
+      <ul class="simple">
+        <li>
+          <p>
+            <a class="reference internal" href="#Bar\A::simplify" title="Bar\A::simplify">
+              <code class="xref php php-meth docutils literal notranslate">
+                <span class="pre">A::simplify</span>
+              </code>
+            </a>
+          </p>
+        </li>
+        <li>
+          <p>
+            <code class="xref php php-meth docutils literal notranslate">
+              <span class="pre">A::simplify</span>
+            </code>
+          </p>
+        </li>
+        <li>
+          <p>
+            <a class="reference internal" href="#Bar\A2::simplify" title="Bar\A2::simplify">
+              <code class="xref php php-meth docutils literal notranslate">
+                <span class="pre">A2::simplify</span>
+              </code>
+            </a>
+          </p>
+        </li>
+        <li>
+          <p>
+            <a class="reference internal" href="#Bar\A2::simplify" title="Bar\A2::simplify">
+              <code class="xref php php-meth docutils literal notranslate">
+                <span class="pre">Bar\A2::simplify</span>
+              </code>
+            </a>
+          </p>
+        </li>
+      </ul>
+    </section>
+  </section>
   <section id="ns-must-not-be-guessed">
     <h1>NS must not be guessed<a class="headerlink" href="#ns-must-not-be-guessed" title="Permalink to this heading">&#xB6;</a></h1>
     <div class="note docutils">

--- a/test/ns.html
+++ b/test/ns.html
@@ -38,7 +38,7 @@
         <li>
           <p>
             <a class="reference internal" href="#Foo\A::simplify" title="Foo\A::simplify">
-              <code class="xref php php-meth docutils literal notranslate">
+              <code class="xref php php-method docutils literal notranslate">
                 <span class="pre">A::simplify</span>
               </code>
             </a>
@@ -115,7 +115,7 @@
         <li>
           <p>
             <a class="reference internal" href="#Bar\A::simplify" title="Bar\A::simplify">
-              <code class="xref php php-meth docutils literal notranslate">
+              <code class="xref php php-method docutils literal notranslate">
                 <span class="pre">A::simplify</span>
               </code>
             </a>
@@ -124,7 +124,7 @@
         <li>
           <p>
             <a class="reference internal" href="#Foo\Bar\A::simplify" title="Foo\Bar\A::simplify">
-              <code class="xref php php-meth docutils literal notranslate">
+              <code class="xref php php-method docutils literal notranslate">
                 <span class="pre">Foo\Bar\A::simplify</span>
               </code>
             </a>
@@ -133,7 +133,7 @@
         <li>
           <p>
             <a class="reference internal" href="#Bar\A::simplify" title="Bar\A::simplify">
-              <code class="xref php php-meth docutils literal notranslate">
+              <code class="xref php php-method docutils literal notranslate">
                 <span class="pre">Bar\A::simplify</span>
               </code>
             </a>
@@ -248,7 +248,7 @@
     <ul class="simple">
       <li>
         <p>
-          <code class="xref php php-meth docutils literal notranslate">
+          <code class="xref php php-method docutils literal notranslate">
             <span class="pre">A2::simplify</span>
           </code>
         </p>
@@ -258,7 +258,7 @@
     <ul class="simple">
       <li>
         <p>
-          <code class="xref php php-meth docutils literal notranslate">
+          <code class="xref php php-method docutils literal notranslate">
             <span class="pre">A::simplify</span>
           </code>
         </p>

--- a/test/ns.md
+++ b/test/ns.md
@@ -11,7 +11,7 @@
 
 ## Cross linking
 
-- {php:meth}`A::simplify`
+- {php:method}`A::simplify`
 
 # NS can be changed
 
@@ -35,9 +35,9 @@
 
 ## Cross linking
 
-- {php:meth}`A::simplify`
-- {php:meth}`\Foo\Bar\A::simplify`
-- {php:meth}`\Bar\A::simplify`
+- {php:method}`A::simplify`
+- {php:method}`\Foo\Bar\A::simplify`
+- {php:method}`\Bar\A::simplify`
 
 # Leading `\` implies absolute class name
 
@@ -66,9 +66,9 @@
 These cross references must not have a link as the target methods are not defined.
 :::
 
-- {php:meth}`\A2::simplify`
+- {php:method}`\A2::simplify`
 
 :::{php:namespace} Bar2
 :::
 
-- {php:meth}`A::simplify`
+- {php:method}`A::simplify`

--- a/test/ns.md
+++ b/test/ns.md
@@ -39,6 +39,27 @@
 - {php:meth}`\Foo\Bar\A::simplify`
 - {php:meth}`\Bar\A::simplify`
 
+# Leading `\` implies absolute class name
+
+:::{php:class} \A
+:::
+
+:::{php:method} simplify()
+:::
+
+:::{php:class} A2
+:::
+
+:::{php:method} simplify()
+:::
+
+## Cross linking
+
+- {php:meth}`A::simplify`
+- {php:meth}`\A::simplify`
+- {php:meth}`A2::simplify`
+- {php:meth}`\Bar\A2::simplify`
+
 # NS must not be guessed
 
 :::note

--- a/test/rst_doc.html
+++ b/test/rst_doc.html
@@ -436,14 +436,14 @@
         </p>
         <p>
           <a class="reference internal" href="#in_array" title="in_array">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">in_array</span>
             </code>
           </a>
         </p>
         <p>
           <a class="reference internal" href="#strpos" title="strpos">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">strpos</span>
             </code>
           </a>
@@ -916,7 +916,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\namespaced_function" title="LibraryName\namespaced_function">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">namespaced_function()</span>
             </code>
           </a>
@@ -937,7 +937,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClass::instanceMethod" title="LibraryName\LibraryClass::instanceMethod">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">LibraryClass::instanceMethod</span>
             </code>
           </a>
@@ -972,7 +972,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\NamespaceClass::firstMethod" title="LibraryName\NamespaceClass::firstMethod">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">NamespaceClass::firstMethod</span>
             </code>
           </a>
@@ -1049,7 +1049,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryInterface::instanceMethod" title="LibraryName\LibraryInterface::instanceMethod">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">LibraryInterface::instanceMethod</span>
             </code>
           </a>
@@ -1096,7 +1096,7 @@
         <p>All of the following links should not be prefixed with a classname.</p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClass::instanceMethod" title="LibraryName\LibraryClass::instanceMethod">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">instanceMethod</span>
             </code>
           </a>
@@ -1127,7 +1127,7 @@
         </p>
         <p>
           <a class="reference internal" href="#DateTime::setTime" title="DateTime::setTime">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">DateTime::setTime()</span>
             </code>
           </a>
@@ -1148,7 +1148,7 @@
         </p>
         <p>
           <a class="reference internal" href="#in_array" title="in_array">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">in_array()</span>
             </code>
           </a>
@@ -1184,7 +1184,7 @@
         </p>
         <p>
           <a class="reference internal" href="#DateTimeInterface::setTime" title="DateTimeInterface::setTime">
-            <code class="xref php php-func docutils literal notranslate">
+            <code class="xref php php-function docutils literal notranslate">
               <span class="pre">DateTimeInterface::setTime()</span>
             </code>
           </a>
@@ -1195,14 +1195,14 @@
       <h2>Any Cross Ref<a class="headerlink" href="#any-cross-ref" title="Permalink to this heading">&#xB6;</a></h2>
       <p>
         <a class="reference internal" href="#LibraryName\NS_CONST" title="LibraryName\NS_CONST">
-          <code class="xref any php php-func docutils literal notranslate">
+          <code class="xref any php php-function docutils literal notranslate">
             <span class="pre">LibraryName\NS_CONST</span>
           </code>
         </a>
       </p>
       <p>
         <a class="reference internal" href="#DateTimeInterface::setTime" title="DateTimeInterface::setTime">
-          <code class="xref any php php-func docutils literal notranslate">
+          <code class="xref any php php-function docutils literal notranslate">
             <span class="pre">DateTimeInterface::setTime()</span>
           </code>
         </a>

--- a/test/rst_doc.html
+++ b/test/rst_doc.html
@@ -909,7 +909,7 @@
         <p>Within a namespace context you don&#x2019;t need to include the namespace in links.</p>
         <p>
           <a class="reference internal" href="#namespace-LibraryName">
-            <code class="xref php php-ns docutils literal notranslate">
+            <code class="xref php php-namespace docutils literal notranslate">
               <span class="pre">LibraryName</span>
             </code>
           </a>
@@ -1249,13 +1249,13 @@
         <h3>Test Case - Test subpackage links<a class="headerlink" href="#test-case-test-subpackage-links" title="Permalink to this heading">&#xB6;</a></h3>
         <p>
           <a class="reference internal" href="#namespace-LibraryName\SubPackage">
-            <code class="xref php php-ns docutils literal notranslate">
+            <code class="xref php php-namespace docutils literal notranslate">
               <span class="pre">LibraryName\SubPackage</span>
             </code>
           </a>
         </p>
         <p>
-          <code class="xref php php-ns docutils literal notranslate">
+          <code class="xref php php-namespace docutils literal notranslate">
             <span class="pre">LibraryName\SubPackage</span>
           </code>
         </p>

--- a/test/rst_doc.html
+++ b/test/rst_doc.html
@@ -687,9 +687,6 @@
           <p>A class in a namespace</p>
           <dl class="php method">
             <dt class="sig sig-object php" id="LibraryName\LibraryClass::instanceMethod">
-              <span class="sig-prename descclassname">
-                <span class="pre">LibraryClass::</span>
-              </span>
               <span class="sig-name descname">
                 <span class="pre">instanceMethod</span>
               </span>

--- a/test/rst_doc.html
+++ b/test/rst_doc.html
@@ -174,18 +174,18 @@
               <p>Y-m-dTH:i:sP</p>
             </dd>
           </dl>
-          <dl class="php attr">
-            <dt class="sig sig-object php" id="DateTime::$testattr">
+          <dl class="php property">
+            <dt class="sig sig-object php" id="DateTime::$testprop">
               <em class="property">
                 <span class="pre">property</span>
               </em>
               <span class="sig-name descname">
-                <span class="pre">testattr</span>
+                <span class="pre">testprop</span>
               </span>
-              <a class="headerlink" href="#DateTime::$testattr" title="Permalink to this definition">&#xB6;</a>
+              <a class="headerlink" href="#DateTime::$testprop" title="Permalink to this definition">&#xB6;</a>
             </dt>
             <dd>
-              <p>Value of some attribute</p>
+              <p>Value of some property</p>
             </dd>
           </dl>
         </dd>
@@ -210,8 +210,8 @@
           <p>Update something.</p>
         </dd>
       </dl>
-      <dl class="php attr">
-        <dt class="sig sig-object php" id="OtherClass::$nonIndentedAttribute">
+      <dl class="php property">
+        <dt class="sig sig-object php" id="OtherClass::$nonIndentedProperty">
           <em class="property">
             <span class="pre">property</span>
           </em>
@@ -219,12 +219,12 @@
             <span class="pre">OtherClass::$</span>
           </span>
           <span class="sig-name descname">
-            <span class="pre">nonIndentedAttribute</span>
+            <span class="pre">nonIndentedProperty</span>
           </span>
-          <a class="headerlink" href="#OtherClass::$nonIndentedAttribute" title="Permalink to this definition">&#xB6;</a>
+          <a class="headerlink" href="#OtherClass::$nonIndentedProperty" title="Permalink to this definition">&#xB6;</a>
         </dt>
         <dd>
-          <p>This attribute wasn&#x2019;t indented</p>
+          <p>This property wasn&#x2019;t indented</p>
         </dd>
       </dl>
       <dl class="php const">
@@ -338,18 +338,18 @@
               <p>Y-m-dTH:i:sP</p>
             </dd>
           </dl>
-          <dl class="php attr">
-            <dt class="sig sig-object php" id="DateTimeInterface::$testattr">
+          <dl class="php property">
+            <dt class="sig sig-object php" id="DateTimeInterface::$testprop">
               <em class="property">
                 <span class="pre">property</span>
               </em>
               <span class="sig-name descname">
-                <span class="pre">testattr</span>
+                <span class="pre">testprop</span>
               </span>
-              <a class="headerlink" href="#DateTimeInterface::$testattr" title="Permalink to this definition">&#xB6;</a>
+              <a class="headerlink" href="#DateTimeInterface::$testprop" title="Permalink to this definition">&#xB6;</a>
             </dt>
             <dd>
-              <p>Value of some attribute</p>
+              <p>Value of some property</p>
             </dd>
           </dl>
         </dd>
@@ -484,9 +484,9 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="#DateTime::$testattr" title="DateTime::$testattr">
-            <code class="xref php php-attr docutils literal notranslate">
-              <span class="pre">DateTime::$testattr</span>
+          <a class="reference internal" href="#DateTime::$testprop" title="DateTime::$testprop">
+            <code class="xref php php-property docutils literal notranslate">
+              <span class="pre">DateTime::$testprop</span>
             </code>
           </a>
         </p>
@@ -498,9 +498,9 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="#OtherClass::$nonIndentedAttribute" title="OtherClass::$nonIndentedAttribute">
-            <code class="xref php php-attr docutils literal notranslate">
-              <span class="pre">OtherClass::$nonIndentedAttribute</span>
+          <a class="reference internal" href="#OtherClass::$nonIndentedProperty" title="OtherClass::$nonIndentedProperty">
+            <code class="xref php php-property docutils literal notranslate">
+              <span class="pre">OtherClass::$nonIndentedProperty</span>
             </code>
           </a>
         </p>
@@ -547,9 +547,9 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="#DateTimeInterface::$testattr" title="DateTimeInterface::$testattr">
-            <code class="xref php php-attr docutils literal notranslate">
-              <span class="pre">DateTimeInterface::$testattr</span>
+          <a class="reference internal" href="#DateTimeInterface::$testprop" title="DateTimeInterface::$testprop">
+            <code class="xref php php-property docutils literal notranslate">
+              <span class="pre">DateTimeInterface::$testprop</span>
             </code>
           </a>
         </p>
@@ -586,9 +586,9 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="#DateTime::$testattr" title="DateTime::$testattr">
-            <code class="xref php php-attr docutils literal notranslate">
-              <span class="pre">$testattr</span>
+          <a class="reference internal" href="#DateTime::$testprop" title="DateTime::$testprop">
+            <code class="xref php php-property docutils literal notranslate">
+              <span class="pre">$testprop</span>
             </code>
           </a>
         </p>
@@ -678,7 +678,7 @@
               <p>Test constant</p>
             </dd>
           </dl>
-          <dl class="php attr">
+          <dl class="php property">
             <dt class="sig sig-object php" id="LibraryName\LibraryClass::$property">
               <em class="property">
                 <span class="pre">property</span>
@@ -717,7 +717,7 @@
           <p>A normal instance method.</p>
         </dd>
       </dl>
-      <dl class="php attr">
+      <dl class="php property">
         <dt class="sig sig-object php" id="LibraryName\NamespaceClass::$property">
           <em class="property">
             <span class="pre">property</span>
@@ -944,7 +944,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClass::$property" title="LibraryName\LibraryClass::$property">
-            <code class="xref php php-attr docutils literal notranslate">
+            <code class="xref php php-property docutils literal notranslate">
               <span class="pre">LibraryClass::$property</span>
             </code>
           </a>
@@ -979,7 +979,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\NamespaceClass::$property" title="LibraryName\NamespaceClass::$property">
-            <code class="xref php php-attr docutils literal notranslate">
+            <code class="xref php php-property docutils literal notranslate">
               <span class="pre">NamespaceClass::$property</span>
             </code>
           </a>
@@ -1110,7 +1110,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClass::$property" title="LibraryName\LibraryClass::$property">
-            <code class="xref php php-attr docutils literal notranslate">
+            <code class="xref php php-property docutils literal notranslate">
               <span class="pre">$property</span>
             </code>
           </a>
@@ -1155,12 +1155,12 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClass::$property" title="LibraryName\LibraryClass::$property">
-            <code class="xref php php-attr docutils literal notranslate">
+            <code class="xref php php-property docutils literal notranslate">
               <span class="pre">LibraryName\LibraryClass::$property</span>
             </code>
           </a>
         </p>
-        <p><a class="reference internal" href="#LibraryName\LibraryClass::$property" title="LibraryName\LibraryClass::$property"><code class="xref php php-attr docutils literal notranslate"><span class="pre">$property</span></code></a> Should not be prefixed with classname.</p>
+        <p><a class="reference internal" href="#LibraryName\LibraryClass::$property" title="LibraryName\LibraryClass::$property"><code class="xref php php-property docutils literal notranslate"><span class="pre">$property</span></code></a> Should not be prefixed with classname.</p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClass::TEST_CONST" title="LibraryName\LibraryClass::TEST_CONST">
             <code class="xref php php-const docutils literal notranslate">

--- a/test/rst_doc.html
+++ b/test/rst_doc.html
@@ -964,13 +964,6 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="rst_doc2.html#LibraryName\ThirdClass" title="LibraryName\ThirdClass">
-            <code class="xref php php-class docutils literal notranslate">
-              <span class="pre">ThirdClass</span>
-            </code>
-          </a>
-        </p>
-        <p>
           <a class="reference internal" href="#LibraryName\NamespaceClass" title="LibraryName\NamespaceClass">
             <code class="xref php php-class docutils literal notranslate">
               <span class="pre">NamespaceClass</span>

--- a/test/rst_doc.html
+++ b/test/rst_doc.html
@@ -266,23 +266,6 @@
         </dd>
       </dl>
     </section>
-    <section id="exceptions">
-      <h2>Exceptions<a class="headerlink" href="#exceptions" title="Permalink to this heading">&#xB6;</a></h2>
-      <dl class="php exception">
-        <dt class="sig sig-object php" id="InvalidArgumentException">
-          <em class="property">
-            <span class="pre">exception</span>
-          </em>
-          <span class="sig-name descname">
-            <span class="pre">InvalidArgumentException</span>
-          </span>
-          <a class="headerlink" href="#InvalidArgumentException" title="Permalink to this definition">&#xB6;</a>
-        </dt>
-        <dd>
-          <p>Throw when you get an argument that is bad.</p>
-        </dd>
-      </dl>
-    </section>
     <section id="interfaces">
       <h2>Interfaces<a class="headerlink" href="#interfaces" title="Permalink to this heading">&#xB6;</a></h2>
       <dl class="php interface">
@@ -536,13 +519,6 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="#InvalidArgumentException" title="InvalidArgumentException">
-            <code class="xref php php-exc docutils literal notranslate">
-              <span class="pre">InvalidArgumentException</span>
-            </code>
-          </a>
-        </p>
-        <p>
           <a class="reference internal" href="#DateTimeInterface" title="DateTimeInterface">
             <code class="xref php php-interface docutils literal notranslate">
               <span class="pre">DateTimeInterface</span>
@@ -655,23 +631,6 @@
         </dt>
         <dd>
           <p>A constant in a namespace</p>
-        </dd>
-      </dl>
-      <dl class="php exception">
-        <dt class="sig sig-object php" id="LibraryName\NamespaceException">
-          <em class="property">
-            <span class="pre">exception</span>
-          </em>
-          <span class="sig-prename descclassname">
-            <span class="pre">LibraryName\</span>
-          </span>
-          <span class="sig-name descname">
-            <span class="pre">NamespaceException</span>
-          </span>
-          <a class="headerlink" href="#LibraryName\NamespaceException" title="Permalink to this definition">&#xB6;</a>
-        </dt>
-        <dd>
-          <p>This exception is in a namespace.</p>
         </dd>
       </dl>
       <dl class="php class">
@@ -1103,13 +1062,6 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="#LibraryName\NamespaceException" title="LibraryName\NamespaceException">
-            <code class="xref php php-exc docutils literal notranslate">
-              <span class="pre">NamespaceException</span>
-            </code>
-          </a>
-        </p>
-        <p>
           <a class="reference internal" href="#LibraryName\TemplateTrait" title="LibraryName\TemplateTrait">
             <code class="xref php php-trait docutils literal notranslate">
               <span class="pre">TemplateTrait</span>
@@ -1145,13 +1097,6 @@
           <a class="reference internal" href="#LibraryName\TemplateTrait" title="LibraryName\TemplateTrait">
             <code class="xref php php-trait docutils literal notranslate">
               <span class="pre">TemplateTrait</span>
-            </code>
-          </a>
-        </p>
-        <p>
-          <a class="reference internal" href="#LibraryName\NamespaceException" title="LibraryName\NamespaceException">
-            <code class="xref php php-exc docutils literal notranslate">
-              <span class="pre">NamespaceException</span>
             </code>
           </a>
         </p>
@@ -1273,23 +1218,6 @@
     <section id="namespace-LibraryName\SubPackage">
       <span id="nested-namespaces"/>
       <h2>Nested namespaces<a class="headerlink" href="#namespace-LibraryName\SubPackage" title="Permalink to this heading">&#xB6;</a></h2>
-      <dl class="php exception">
-        <dt class="sig sig-object php" id="LibraryName\SubPackage\NestedNamespaceException">
-          <em class="property">
-            <span class="pre">exception</span>
-          </em>
-          <span class="sig-prename descclassname">
-            <span class="pre">LibraryName\SubPackage\</span>
-          </span>
-          <span class="sig-name descname">
-            <span class="pre">NestedNamespaceException</span>
-          </span>
-          <a class="headerlink" href="#LibraryName\SubPackage\NestedNamespaceException" title="Permalink to this definition">&#xB6;</a>
-        </dt>
-        <dd>
-          <p>In a package</p>
-        </dd>
-      </dl>
       <dl class="php class">
         <dt class="sig sig-object php" id="LibraryName\SubPackage\SubpackageClass">
           <em class="property">
@@ -1363,20 +1291,6 @@
           <a class="reference internal" href="#LibraryName\SubPackage\SubpackageInterface" title="LibraryName\SubPackage\SubpackageInterface">
             <code class="xref php php-class docutils literal notranslate">
               <span class="pre">LibraryName\SubPackage\SubpackageInterface</span>
-            </code>
-          </a>
-        </p>
-        <p>
-          <a class="reference internal" href="#LibraryName\SubPackage\NestedNamespaceException" title="LibraryName\SubPackage\NestedNamespaceException">
-            <code class="xref php php-exc docutils literal notranslate">
-              <span class="pre">NestedNamespaceException</span>
-            </code>
-          </a>
-        </p>
-        <p>
-          <a class="reference internal" href="#LibraryName\SubPackage\NestedNamespaceException" title="LibraryName\SubPackage\NestedNamespaceException">
-            <code class="xref php php-exc docutils literal notranslate">
-              <span class="pre">LibraryName\SubPackage\NestedNamespaceException</span>
             </code>
           </a>
         </p>
@@ -1512,36 +1426,6 @@
                       <a class="reference internal" href="#SOME_CONSTANT" title="SOME_CONSTANT">
                         <code class="xref php php-obj docutils literal notranslate">
                           <span class="pre">SOME_CONSTANT</span>
-                        </code>
-                      </a>
-                    </span>
-                  </p>
-                </dd>
-              </dl>
-            </dd>
-          </dl>
-          <dl class="php method">
-            <dt class="sig sig-object php" id="OtherLibrary\ReturningClass::returnExceptionInstance">
-              <span class="sig-name descname">
-                <span class="pre">returnExceptionInstance</span>
-              </span>
-              <span class="sig-paren">(</span>
-              <span class="sig-paren">)</span>
-              <a class="headerlink" href="#OtherLibrary\ReturningClass::returnExceptionInstance" title="Permalink to this definition">&#xB6;</a>
-            </dt>
-            <dd>
-              <dl class="field-list simple">
-                <dt class="field-odd">Returns<span class="colon">:</span></dt>
-                <dd class="field-odd">
-                  <p>An instance of an exception.</p>
-                </dd>
-                <dt class="field-even">Return type<span class="colon">:</span></dt>
-                <dd class="field-even">
-                  <p>
-                    <span>
-                      <a class="reference internal" href="#InvalidArgumentException" title="InvalidArgumentException">
-                        <code class="xref php php-obj docutils literal notranslate">
-                          <span class="pre">InvalidArgumentException</span>
                         </code>
                       </a>
                     </span>

--- a/test/rst_doc.html
+++ b/test/rst_doc.html
@@ -457,21 +457,21 @@
         </p>
         <p>
           <a class="reference internal" href="#DateTime::setTime" title="DateTime::setTime">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">DateTime::setTime()</span>
             </code>
           </a>
         </p>
         <p>
           <a class="reference internal" href="#DateTime::getLastErrors" title="DateTime::getLastErrors">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">DateTime::getLastErrors()</span>
             </code>
           </a>
         </p>
         <p>
           <a class="reference internal" href="#DateTime::setDate" title="DateTime::setDate">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">DateTime::setDate()</span>
             </code>
           </a>
@@ -492,7 +492,7 @@
         </p>
         <p>
           <a class="reference internal" href="#OtherClass::update" title="OtherClass::update">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">OtherClass::update</span>
             </code>
           </a>
@@ -513,7 +513,7 @@
         </p>
         <p>
           <a class="reference internal" href="#OtherClass2::update" title="OtherClass2::update">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">OtherClass2::update()</span>
             </code>
           </a>
@@ -527,14 +527,14 @@
         </p>
         <p>
           <a class="reference internal" href="#DateTimeInterface::setTime" title="DateTimeInterface::setTime">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">DateTimeInterface::setTime()</span>
             </code>
           </a>
         </p>
         <p>
           <a class="reference internal" href="#DateTimeInterface::setDate" title="DateTimeInterface::setDate">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">setDate()</span>
             </code>
           </a>
@@ -569,7 +569,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LogTrait::log" title="LogTrait::log">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">LogTrait::log()</span>
             </code>
           </a>
@@ -580,7 +580,7 @@
         <p>The following links should not be prefixed with a classname.</p>
         <p>
           <a class="reference internal" href="#DateTime::setDate" title="DateTime::setDate">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">setDate()</span>
             </code>
           </a>
@@ -993,7 +993,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\NamespaceClass2::update" title="LibraryName\NamespaceClass2::update">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">NamespaceClass2::update()</span>
             </code>
           </a>
@@ -1007,35 +1007,35 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClassFinal::firstMethod" title="LibraryName\LibraryClassFinal::firstMethod">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">LibraryClassFinal::firstMethod</span>
             </code>
           </a>
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClassFinal::secondMethod" title="LibraryName\LibraryClassFinal::secondMethod">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">LibraryClassFinal::secondMethod</span>
             </code>
           </a>
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClassFinal::thirdMethod" title="LibraryName\LibraryClassFinal::thirdMethod">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">LibraryClassFinal::thirdMethod</span>
             </code>
           </a>
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClassFinal::fourthMethod" title="LibraryName\LibraryClassFinal::fourthMethod">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">LibraryClassFinal::fourthMethod</span>
             </code>
           </a>
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\LibraryClassFinal::fifthMethod" title="LibraryName\LibraryClassFinal::fifthMethod">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">LibraryClassFinal::fifthMethod</span>
             </code>
           </a>
@@ -1063,7 +1063,7 @@
         </p>
         <p>
           <a class="reference internal" href="#LibraryName\TemplateTrait::render" title="LibraryName\TemplateTrait::render">
-            <code class="xref php php-meth docutils literal notranslate">
+            <code class="xref php php-method docutils literal notranslate">
               <span class="pre">TemplateTrait::render()</span>
             </code>
           </a>
@@ -2013,14 +2013,14 @@ deck are divided.</p>
           </p>
           <p>
             <a class="reference internal" href="#Example\Advanced\Suit::color" title="Example\Advanced\Suit::color">
-              <code class="xref php php-meth docutils literal notranslate">
+              <code class="xref php php-method docutils literal notranslate">
                 <span class="pre">Suit::color</span>
               </code>
             </a>
           </p>
           <p>
             <a class="reference internal" href="#Example\Advanced\Suit::values" title="Example\Advanced\Suit::values">
-              <code class="xref php php-meth docutils literal notranslate">
+              <code class="xref php php-method docutils literal notranslate">
                 <span class="pre">Suit::values</span>
               </code>
             </a>

--- a/test/rst_doc.html
+++ b/test/rst_doc.html
@@ -244,21 +244,25 @@
           <p>This class constant wasn&#x2019;t indented</p>
         </dd>
       </dl>
-      <dl class="php staticmethod">
-        <dt class="sig sig-object php" id="OtherClass::staticMethod">
-          <em class="property">
-            <span class="pre">static</span>
-          </em>
+      <dl class="php method">
+        <dt class="sig sig-object php" id="OtherClass2::update">
           <span class="sig-prename descclassname">
-            <span class="pre">OtherClass::</span>
+            <span class="pre">OtherClass2::</span>
           </span>
           <span class="sig-name descname">
-            <span class="pre">staticMethod</span>
+            <span class="pre">update</span>
           </span>
-          <a class="headerlink" href="#OtherClass::staticMethod" title="Permalink to this definition">&#xB6;</a>
+          <span class="sig-paren">(</span>
+          <em class="sig-param">
+            <span class="pre">$arg</span>
+            <span class="pre">=</span>
+            <span class="pre">''</span>
+          </em>
+          <span class="sig-paren">)</span>
+          <a class="headerlink" href="#OtherClass2::update" title="Permalink to this definition">&#xB6;</a>
         </dt>
         <dd>
-          <p>A static method.</p>
+          <p>A method without explicitly declared class block.</p>
         </dd>
       </dl>
     </section>
@@ -525,9 +529,9 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="#OtherClass::staticMethod" title="OtherClass::staticMethod">
-            <code class="xref php php-func docutils literal notranslate">
-              <span class="pre">OtherClass::staticMethod</span>
+          <a class="reference internal" href="#OtherClass2::update" title="OtherClass2::update">
+            <code class="xref php php-meth docutils literal notranslate">
+              <span class="pre">OtherClass2::update()</span>
             </code>
           </a>
         </p>
@@ -731,23 +735,6 @@
           </dl>
         </dd>
       </dl>
-      <dl class="php staticmethod">
-        <dt class="sig sig-object php" id="LibraryName\LibraryClass::staticMethod">
-          <em class="property">
-            <span class="pre">static</span>
-          </em>
-          <span class="sig-prename descclassname">
-            <span class="pre">LibraryName\LibraryClass::</span>
-          </span>
-          <span class="sig-name descname">
-            <span class="pre">staticMethod</span>
-          </span>
-          <a class="headerlink" href="#LibraryName\LibraryClass::staticMethod" title="Permalink to this definition">&#xB6;</a>
-        </dt>
-        <dd>
-          <p>A static method in a namespace</p>
-        </dd>
-      </dl>
       <dl class="php class">
         <dt class="sig sig-object php" id="LibraryName\NamespaceClass">
           <em class="property">
@@ -805,26 +792,23 @@
           <p>Const on class in namespace</p>
         </dd>
       </dl>
-      <dl class="php staticmethod">
-        <dt class="sig sig-object php" id="LibraryName\NamespaceClass::namespaceStatic">
-          <em class="property">
-            <span class="pre">static</span>
-          </em>
+      <dl class="php method">
+        <dt class="sig sig-object php" id="LibraryName\NamespaceClass2::update">
           <span class="sig-prename descclassname">
-            <span class="pre">LibraryName\NamespaceClass::</span>
+            <span class="pre">LibraryName\NamespaceClass2::</span>
           </span>
           <span class="sig-name descname">
-            <span class="pre">namespaceStatic</span>
+            <span class="pre">update</span>
           </span>
           <span class="sig-paren">(</span>
           <em class="sig-param">
             <span class="pre">$foo</span>
           </em>
           <span class="sig-paren">)</span>
-          <a class="headerlink" href="#LibraryName\NamespaceClass::namespaceStatic" title="Permalink to this definition">&#xB6;</a>
+          <a class="headerlink" href="#LibraryName\NamespaceClass2::update" title="Permalink to this definition">&#xB6;</a>
         </dt>
         <dd>
-          <p>A static method here.</p>
+          <p>A method without explicitly declared class block in a namespace</p>
         </dd>
       </dl>
       <dl class="php class">
@@ -1000,13 +984,6 @@
           </a>
         </p>
         <p>
-          <a class="reference internal" href="#LibraryName\LibraryClass::staticMethod" title="LibraryName\LibraryClass::staticMethod">
-            <code class="xref php php-func docutils literal notranslate">
-              <span class="pre">LibraryClass::staticMethod()</span>
-            </code>
-          </a>
-        </p>
-        <p>
           <a class="reference internal" href="#LibraryName\LibraryClass::$property" title="LibraryName\LibraryClass::$property">
             <code class="xref php php-attr docutils literal notranslate">
               <span class="pre">LibraryClass::$property</span>
@@ -1059,6 +1036,13 @@
           <a class="reference internal" href="#LibraryName\NamespaceClass::NAMESPACE_CONST" title="LibraryName\NamespaceClass::NAMESPACE_CONST">
             <code class="xref php php-const docutils literal notranslate">
               <span class="pre">NamespaceClass::NAMESPACE_CONST</span>
+            </code>
+          </a>
+        </p>
+        <p>
+          <a class="reference internal" href="#LibraryName\NamespaceClass2::update" title="LibraryName\NamespaceClass2::update">
+            <code class="xref php php-meth docutils literal notranslate">
+              <span class="pre">NamespaceClass2::update()</span>
             </code>
           </a>
         </p>
@@ -1930,7 +1914,7 @@ deck are divided.</p>
                 <p>Returns &#x201C;red&#x201D; for hearts and diamonds, &#x201C;black&#x201D; for clubs and spades.</p>
               </dd>
             </dl>
-            <dl class="php staticmethod">
+            <dl class="php method">
               <dt class="sig sig-object php" id="Example\Advanced\Suit::values">
                 <em class="property">
                   <span class="pre">static</span>
@@ -1938,6 +1922,8 @@ deck are divided.</p>
                 <span class="sig-name descname">
                   <span class="pre">values</span>
                 </span>
+                <span class="sig-paren">(</span>
+                <span class="sig-paren">)</span>
                 <span class="sig-return">
                   <span class="sig-return-icon">&#x2192;</span>
                   <span class="sig-return-typehint">

--- a/test/rst_doc.md
+++ b/test/rst_doc.md
@@ -150,9 +150,9 @@ Test Case - Global symbols with no namespaces
 
 :php:const:`SOME_CONSTANT`
 
-:php:func:`in_array`
+:php:function:`in_array`
 
-:php:func:`strpos`
+:php:function:`strpos`
 
 :php:class:`DateTime`
 
@@ -304,13 +304,13 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:namespace:`LibraryName`
 
-:php:func:`namespaced_function()`
+:php:function:`namespaced_function()`
 
 :php:const:`NS_CONST`
 
 :php:class:`LibraryClass`
 
-:php:func:`LibraryClass::instanceMethod`
+:php:function:`LibraryClass::instanceMethod`
 
 :php:attr:`LibraryClass::$property`
 
@@ -320,7 +320,7 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:class:`NamespaceClass`
 
-:php:func:`NamespaceClass::firstMethod`
+:php:function:`NamespaceClass::firstMethod`
 
 :php:attr:`NamespaceClass::$property`
 
@@ -342,7 +342,7 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:interface:`LibraryInterface`
 
-:php:func:`LibraryInterface::instanceMethod`
+:php:function:`LibraryInterface::instanceMethod`
 
 :php:trait:`TemplateTrait`
 
@@ -361,7 +361,7 @@ All of the following links should not be prefixed with a namespace.
 
 All of the following links should not be prefixed with a classname.
 
-:php:func:`~LibraryClass::instanceMethod`
+:php:function:`~LibraryClass::instanceMethod`
 
 :php:const:`~LibraryClass::TEST_CONST`
 
@@ -373,13 +373,13 @@ Test Case - global access
 
 :php:class:`\\DateTime`
 
-:php:func:`\\DateTime::setTime()`
+:php:function:`\\DateTime::setTime()`
 
 :php:global:`$global_var`
 
 :php:const:`SOME_CONSTANT`
 
-:php:func:`in_array()`
+:php:function:`in_array()`
 
 :php:attr:`\\LibraryName\\LibraryClass::$property`
 
@@ -391,7 +391,7 @@ Test Case - global access
 
 :php:interface:`\\DateTimeInterface`
 
-:php:func:`\\DateTimeInterface::setTime()`
+:php:function:`\\DateTimeInterface::setTime()`
 
 Any Cross Ref
 =============

--- a/test/rst_doc.md
+++ b/test/rst_doc.md
@@ -302,7 +302,7 @@ Test Case - not including namespace
 
 Within a namespace context you don't need to include the namespace in links.
 
-:php:ns:`LibraryName`
+:php:namespace:`LibraryName`
 
 :php:func:`namespaced_function()`
 
@@ -416,9 +416,9 @@ Nested namespaces
 Test Case - Test subpackage links
 ---------------------------------
 
-:php:ns:`LibraryName\\SubPackage`
+:php:namespace:`LibraryName\\SubPackage`
 
-:php:ns:`\\LibraryName\\SubPackage`
+:php:namespace:`\\LibraryName\\SubPackage`
 
 :php:class:`SubpackageClass`
 

--- a/test/rst_doc.md
+++ b/test/rst_doc.md
@@ -318,8 +318,6 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:class:`OtherClass`
 
-:php:class:`ThirdClass`
-
 :php:class:`NamespaceClass`
 
 :php:func:`NamespaceClass::firstMethod`

--- a/test/rst_doc.md
+++ b/test/rst_doc.md
@@ -59,9 +59,9 @@ Classes
 
         Y-m-d\TH:i:sP
 
-    .. php:attr:: testattr
+    .. php:property:: testprop
 
-        Value of some attribute
+        Value of some property
 
 .. php:class:: OtherClass
 
@@ -71,9 +71,9 @@ Classes
 
     Update something.
 
-.. php:attr:: nonIndentedAttribute
+.. php:property:: nonIndentedProperty
 
-    This attribute wasn't indented
+    This property wasn't indented
 
 .. php:const:: NO_INDENT
 
@@ -110,9 +110,9 @@ Interfaces
 
         Y-m-d\TH:i:sP
 
-    .. php:attr:: testattr
+    .. php:property:: testprop
 
-        Value of some attribute
+        Value of some property
 
 .. php:interface:: OtherInterface
 
@@ -164,11 +164,11 @@ Test Case - Global symbols with no namespaces
 
 :php:const:`DateTime::ATOM`
 
-:php:attr:`DateTime::$testattr`
+:php:property:`DateTime::$testprop`
 
 :php:method:`OtherClass::update`
 
-:php:attr:`OtherClass::$nonIndentedAttribute`
+:php:property:`OtherClass::$nonIndentedProperty`
 
 :php:const:`OtherClass::NO_INDENT`
 
@@ -182,7 +182,7 @@ Test Case - Global symbols with no namespaces
 
 :php:const:`DateTimeInterface::ATOM`
 
-:php:attr:`DateTimeInterface::$testattr`
+:php:property:`DateTimeInterface::$testprop`
 
 :php:interface:`OtherInterface`
 
@@ -197,7 +197,7 @@ The following links should not be prefixed with a classname.
 
 :php:method:`~DateTime::setDate()`
 
-:php:attr:`~DateTime::$testattr`
+:php:property:`~DateTime::$testprop`
 
 
 Namespaced elements
@@ -228,7 +228,7 @@ Namespaced elements
 
         Test constant
 
-    .. php:attr:: property
+    .. php:property:: property
 
         A property!
 
@@ -240,7 +240,7 @@ Namespaced elements
 
     A normal instance method.
 
-.. php:attr:: property
+.. php:property:: property
 
     A property
 
@@ -312,7 +312,7 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:function:`LibraryClass::instanceMethod`
 
-:php:attr:`LibraryClass::$property`
+:php:property:`LibraryClass::$property`
 
 :php:const:`LibraryClass::TEST_CONST`
 
@@ -322,7 +322,7 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:function:`NamespaceClass::firstMethod`
 
-:php:attr:`NamespaceClass::$property`
+:php:property:`NamespaceClass::$property`
 
 :php:const:`NamespaceClass::NAMESPACE_CONST`
 
@@ -365,7 +365,7 @@ All of the following links should not be prefixed with a classname.
 
 :php:const:`~LibraryClass::TEST_CONST`
 
-:php:attr:`~LibraryClass::$property`
+:php:property:`~LibraryClass::$property`
 
 
 Test Case - global access
@@ -381,9 +381,9 @@ Test Case - global access
 
 :php:function:`in_array()`
 
-:php:attr:`\\LibraryName\\LibraryClass::$property`
+:php:property:`\\LibraryName\\LibraryClass::$property`
 
-:php:attr:`~\\LibraryName\\LibraryClass::$property` Should not be prefixed with classname.
+:php:property:`~\\LibraryName\\LibraryClass::$property` Should not be prefixed with classname.
 
 :php:const:`\\LibraryName\\LibraryClass::TEST_CONST`
 

--- a/test/rst_doc.md
+++ b/test/rst_doc.md
@@ -156,29 +156,29 @@ Test Case - Global symbols with no namespaces
 
 :php:class:`DateTime`
 
-:php:meth:`DateTime::setTime()`
+:php:method:`DateTime::setTime()`
 
-:php:meth:`DateTime::getLastErrors()`
+:php:method:`DateTime::getLastErrors()`
 
-:php:meth:`DateTime::setDate()`
+:php:method:`DateTime::setDate()`
 
 :php:const:`DateTime::ATOM`
 
 :php:attr:`DateTime::$testattr`
 
-:php:meth:`OtherClass::update`
+:php:method:`OtherClass::update`
 
 :php:attr:`OtherClass::$nonIndentedAttribute`
 
 :php:const:`OtherClass::NO_INDENT`
 
-:php:meth:`OtherClass2::update()`
+:php:method:`OtherClass2::update()`
 
 :php:interface:`DateTimeInterface`
 
-:php:meth:`DateTimeInterface::setTime()`
+:php:method:`DateTimeInterface::setTime()`
 
-:php:meth:`~DateTimeInterface::setDate()`
+:php:method:`~DateTimeInterface::setDate()`
 
 :php:const:`DateTimeInterface::ATOM`
 
@@ -188,14 +188,14 @@ Test Case - Global symbols with no namespaces
 
 :php:trait:`LogTrait`
 
-:php:meth:`LogTrait::log()`
+:php:method:`LogTrait::log()`
 
 Test Case - Prefix less links
 -----------------------------
 
 The following links should not be prefixed with a classname.
 
-:php:meth:`~DateTime::setDate()`
+:php:method:`~DateTime::setDate()`
 
 :php:attr:`~DateTime::$testattr`
 
@@ -326,19 +326,19 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:const:`NamespaceClass::NAMESPACE_CONST`
 
-:php:meth:`NamespaceClass2::update()`
+:php:method:`NamespaceClass2::update()`
 
 :php:class:`LibraryClassFinal`
 
-:php:meth:`LibraryClassFinal::firstMethod`
+:php:method:`LibraryClassFinal::firstMethod`
 
-:php:meth:`LibraryClassFinal::secondMethod`
+:php:method:`LibraryClassFinal::secondMethod`
 
-:php:meth:`LibraryClassFinal::thirdMethod`
+:php:method:`LibraryClassFinal::thirdMethod`
 
-:php:meth:`LibraryClassFinal::fourthMethod`
+:php:method:`LibraryClassFinal::fourthMethod`
 
-:php:meth:`LibraryClassFinal::fifthMethod`
+:php:method:`LibraryClassFinal::fifthMethod`
 
 :php:interface:`LibraryInterface`
 
@@ -346,7 +346,7 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:trait:`TemplateTrait`
 
-:php:meth:`TemplateTrait::render()`
+:php:method:`TemplateTrait::render()`
 
 Test Case - Links with prefix trimming
 --------------------------------------
@@ -585,9 +585,9 @@ Links to Advanced Enumeration Example
 
 :php:case:`Suit::Spades`
 
-:php:meth:`Suit::color`
+:php:method:`Suit::color`
 
-:php:meth:`Suit::values`
+:php:method:`Suit::values`
 
 :php:const:`Suit::Roses`
 

--- a/test/rst_doc.md
+++ b/test/rst_doc.md
@@ -79,9 +79,9 @@ Classes
 
     This class constant wasn't indented
 
-.. php:staticmethod:: OtherClass::staticMethod()
+.. php:method:: OtherClass2::update($arg = '')
 
-    A static method.
+    A method without explicitly declared class block.
 
 Exceptions
 ==========
@@ -179,7 +179,7 @@ Test Case - Global symbols with no namespaces
 
 :php:const:`OtherClass::NO_INDENT`
 
-:php:func:`OtherClass::staticMethod`
+:php:meth:`OtherClass2::update()`
 
 :php:exc:`InvalidArgumentException`
 
@@ -247,10 +247,6 @@ Namespaced elements
 
         A property!
 
-.. php:staticmethod:: LibraryClass::staticMethod()
-
-    A static method in a namespace
-
 .. php:class:: NamespaceClass
 
     A class in the namespace, no indenting on children
@@ -267,9 +263,9 @@ Namespaced elements
 
     Const on class in namespace
 
-.. php:staticmethod:: namespaceStatic($foo)
+.. php:method:: NamespaceClass2::update($foo)
 
-    A static method here.
+    A method without explicitly declared class block in a namespace
 
 .. php:class:: final LibraryClassFinal
 
@@ -331,8 +327,6 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:func:`LibraryClass::instanceMethod`
 
-:php:func:`LibraryClass::staticMethod()`
-
 :php:attr:`LibraryClass::$property`
 
 :php:const:`LibraryClass::TEST_CONST`
@@ -348,6 +342,8 @@ Within a namespace context you don't need to include the namespace in links.
 :php:attr:`NamespaceClass::$property`
 
 :php:const:`NamespaceClass::NAMESPACE_CONST`
+
+:php:meth:`NamespaceClass2::update()`
 
 :php:class:`LibraryClassFinal`
 
@@ -561,7 +557,7 @@ Advanced Enumerations
 
         Returns "red" for hearts and diamonds, "black" for clubs and spades.
 
-    .. php:staticmethod:: values() -> string[]
+    .. php:method:: static values() -> string[]
 
         Returns an array of the values of all the cases on this enum.
 

--- a/test/rst_doc.md
+++ b/test/rst_doc.md
@@ -83,13 +83,6 @@ Classes
 
     A method without explicitly declared class block.
 
-Exceptions
-==========
-
-.. php:exception:: InvalidArgumentException
-
-    Throw when you get an argument that is bad.
-
 Interfaces
 ==========
 
@@ -181,8 +174,6 @@ Test Case - Global symbols with no namespaces
 
 :php:meth:`OtherClass2::update()`
 
-:php:exc:`InvalidArgumentException`
-
 :php:interface:`DateTimeInterface`
 
 :php:meth:`DateTimeInterface::setTime()`
@@ -224,12 +215,6 @@ Namespaced elements
 .. php:const:: NS_CONST
 
        A constant in a namespace
-
-
-.. php:exception:: NamespaceException
-
-    This exception is in a namespace.
-
 
 .. php:class:: LibraryClass
 
@@ -361,8 +346,6 @@ Within a namespace context you don't need to include the namespace in links.
 
 :php:func:`LibraryInterface::instanceMethod`
 
-:php:exc:`NamespaceException`
-
 :php:trait:`TemplateTrait`
 
 :php:meth:`TemplateTrait::render()`
@@ -377,8 +360,6 @@ All of the following links should not be prefixed with a namespace.
 :php:class:`~LibraryClass`
 
 :php:trait:`~TemplateTrait`
-
-:php:exc:`~NamespaceException`
 
 All of the following links should not be prefixed with a classname.
 
@@ -426,10 +407,6 @@ Nested namespaces
 
 .. php:namespace:: LibraryName\SubPackage
 
-.. php:exception:: NestedNamespaceException
-
-    In a package
-
 .. php:class:: SubpackageClass
 
     A class in a subpackage
@@ -452,10 +429,6 @@ Test Case - Test subpackage links
 :php:interface:`SubpackageInterface`
 
 :php:class:`\\LibraryName\\SubPackage\\SubpackageInterface`
-
-:php:exc:`NestedNamespaceException`
-
-:php:exc:`\\LibraryName\\SubPackage\\NestedNamespaceException`
 
 Return Types
 ============
@@ -485,11 +458,6 @@ Return Types
 
         :returns: The value of a specific global constant. # TODO link is not working without "\\"
         :returntype: SOME_CONSTANT
-
-    .. php:method:: returnExceptionInstance()
-
-        :returns: An instance of an exception.
-        :returntype: \\InvalidArgumentException
 
     .. php:method:: returnScalarType()
 

--- a/test/rst_doc2.html
+++ b/test/rst_doc2.html
@@ -60,24 +60,6 @@
       <h2>Re-used namespace<a class="headerlink" href="#re-used-namespace" title="Permalink to this heading">&#xB6;</a></h2>
       <p>No indexing errors or links should point to this namespace.</p>
       <dl class="php class">
-        <dt class="sig sig-object php" id="LibraryName\ThirdClass">
-          <em class="property">
-            <span class="pre">class</span>
-          </em>
-          <span class="sig-prename descclassname">
-            <span class="pre">LibraryName\</span>
-          </span>
-          <span class="sig-name descname">
-            <span class="pre">ThirdClass</span>
-          </span>
-          <a class="headerlink" href="#LibraryName\ThirdClass" title="Permalink to this definition">&#xB6;</a>
-        </dt>
-        <dd>
-          <p>Another class in a currentmodule block</p>
-        </dd>
-      </dl>
-      <p>No indexing errors or links should point to this namespace.</p>
-      <dl class="php class">
         <dt class="sig sig-object php" id="LibraryName\OtherClass">
           <em class="property">
             <span class="pre">class</span>

--- a/test/rst_doc2.html
+++ b/test/rst_doc2.html
@@ -19,7 +19,7 @@
       </dt>
       <dd/>
     </dl>
-    <p>Instance of this interface is returned by <code class="xref php php-meth docutils literal notranslate"><span class="pre">Imagine\Image\ImageInterface::draw</span></code>.</p>
+    <p>Instance of this interface is returned by <code class="xref php php-method docutils literal notranslate"><span class="pre">Imagine\Image\ImageInterface::draw</span></code>.</p>
     <dl class="php method">
       <dt class="sig sig-object php" id="Imagine\Draw\DrawerInterface::arc"><span class="sig-prename descclassname"><span class="pre">Imagine\Draw\DrawerInterface::</span></span><span class="sig-name descname"><span class="pre">arc</span></span><span class="sig-paren">(</span><em class="sig-param"><span class="pre">PointInterface</span><span class="pre">$center</span></em>, <em class="sig-param"><span class="pre">BoxInterface</span><span class="pre">$size</span></em>, <em class="sig-param"><span class="pre">$start</span></em>, <em class="sig-param"><span class="pre">$end</span></em>, <em class="sig-param"><span class="pre">Color</span><span class="pre">$color</span></em><span class="sig-paren">)</span><a class="headerlink" href="#Imagine\Draw\DrawerInterface::arc" title="Permalink to this definition">&#xB6;</a></dt>
       <dd>

--- a/test/rst_doc2.md
+++ b/test/rst_doc2.md
@@ -27,14 +27,6 @@ Instance of this interface is returned by :php:meth:`\\Imagine\\Image\\ImageInte
 Re-used namespace
 =================
 
-.. php:currentmodule:: LibraryName
-
-No indexing errors or links should point to this namespace.
-
-.. php:class:: ThirdClass
-
-    Another class in a currentmodule block
-
 .. php:currentnamespace:: LibraryName
 
 No indexing errors or links should point to this namespace.

--- a/test/rst_doc2.md
+++ b/test/rst_doc2.md
@@ -8,7 +8,7 @@ namespace ``Imagine\Draw``
 
 .. php:class:: DrawerInterface
 
-Instance of this interface is returned by :php:meth:`\\Imagine\\Image\\ImageInterface::draw`.
+Instance of this interface is returned by :php:method:`\\Imagine\\Image\\ImageInterface::draw`.
 
 .. php:method:: arc(PointInterface $center, BoxInterface $size, $start, $end, Color $color)
 

--- a/test/rst_index.html
+++ b/test/rst_index.html
@@ -15,9 +15,6 @@
               <a class="reference internal" href="rst_doc.html#classes">Classes</a>
             </li>
             <li class="toctree-l2">
-              <a class="reference internal" href="rst_doc.html#exceptions">Exceptions</a>
-            </li>
-            <li class="toctree-l2">
               <a class="reference internal" href="rst_doc.html#interfaces">Interfaces</a>
             </li>
             <li class="toctree-l2">


### PR DESCRIPTION
#60 must be merged first

explicit `staticmethod` is not needed - https://3v4l.org/bQLVp and it was even used wrong in the enum example

and deprecate non-native/shortened naming variants

no BC break - each commit has synced html output, so the changes should be reviewable easily