### PR TITLE
add missing dependency to target

### DIFF
--- a/test/unit/Makefile
+++ b/test/unit/Makefile
@@ -41,7 +41,7 @@ $(BUILDDIR)/html/%.result: $(BUILDDIR)/html/%
 	# to keep fixtures easier to manage.
 	xmllint $(BUILDDIR)/html/$* --xpath '//div[@role="main"]' | xmllint --format - > $(BUILDDIR)/html/$*.result
 
-compareresult-%:
+compareresult-%: $(BUILDDIR)/html/%.result
 	# compare test_doc.html and test_doc.html.result
 	diff -u $* $(BUILDDIR)/html/$*.result
 


### PR DESCRIPTION
When running 'make --shuffle=reverse -C test/unit comparehtml' it will fail with

```
> make[2]: Entering directory '/build/reproducible-path/sphinxcontrib-phpdomain-0.13.0/test/unit'
> Makefile:45: update target 'compareresult-test_doc2.html' due to: target does not exist
> # compare test_doc.html and test_doc.html.result
> diff -u test_doc2.html _build/html/test_doc2.html.result
> diff: _build/html/test_doc2.html.result: No such file or directory
> make[2]: *** [Makefile:46: compareresult-test_doc2.html] Error 2 shuffle=reverse
```

For more details, see:

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1105583

https://trofi.github.io/posts/238-new-make-shuffle-mode.html