### PR TITLE
[fix]: TypeError in phpdomain when fullname is _StrPath object

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -393,7 +393,7 @@ class PhpObject(ObjectDescription):
             objects = self.env.domaindata["php"]["objects"]
             if fullname in objects:
                 self.state_machine.reporter.warning(
-                    "duplicate object description of %s, " % fullname
+                    "duplicate object description of %s, " % str(fullname)
                     + "other instance in "
                     + self.env.doc2path(objects[fullname][0]),
                     line=self.lineno,


### PR DESCRIPTION
Resolves TypeError: can only concatenate str (not "_StrPath") to str in sphinxcontrib/phpdomain.py:396 by explicitly converting fullname to string before string formatting.

The add_target_and_index method was failing when fullname parameter was a _StrPath object instead of a string. Added str() conversion to ensure proper string concatenation in the error message.