### PR TITLE
[refact]: concatenation of str in phpdomain.py

### DIFF
--- a/sphinxcontrib/phpdomain.py
+++ b/sphinxcontrib/phpdomain.py
@@ -393,9 +393,9 @@ class PhpObject(ObjectDescription):
             objects = self.env.domaindata["php"]["objects"]
             if fullname in objects:
                 self.state_machine.reporter.warning(
-                    "duplicate object description of %s, " % str(fullname)
-                    + "other instance in "
-                    + self.env.doc2path(objects[fullname][0]),
+                    f"duplicate object description of {str(fullname)}, \
+                    other instance in "
+                    + str(self.env.doc2path(objects[fullname][0])),
                     line=self.lineno,
                 )
             objects[fullname] = (self.env.docname, self.objtype)


### PR DESCRIPTION

SO: Ubuntu 24.04.3 LTS
Python: 12

run tests:
```
python3 -m venv .venv
pip install -r requirements.txt
make html
```

result:
not exception